### PR TITLE
BZ-1164738 - EJB invocation issues thrown when working with the product

### DIFF
--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexManager.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexManager.java
@@ -53,7 +53,7 @@ public class LuceneIndexManager implements IndexManager {
     }
 
     @Override
-    public LuceneIndex indexOf( final KObjectKey object ) {
+    public synchronized LuceneIndex indexOf( final KObjectKey object ) {
         final KCluster kcluster = kcluster( object );
         final LuceneIndex currentSetup = indexes.get( kcluster );
         if ( currentSetup != null ) {


### PR DESCRIPTION
This in one of three commits (various repositories) to resolve EAP issue with asynchronous ejb methods:

``` plain
Invocation failed on component SimpleAsyncExecutorService for method public void 
org.uberfire.commons.async.SimpleAsyncExecutorService.execute(java.lang.Runnable): 
javax.ejb.ConcurrentAccessTimeoutException: JBAS014373: EJB 3.1 PFD2 4.8.5.5.1 concurrent access 
timeout on org.jboss.invocation.InterceptorContext$Invocation@755032d4 - could not obtain lock within 
5000MILLISECONDS
```

There are several BZ for bpms/brms and this might affect actual indexation of file systems in case it fails - usually bigger filesystem that indexation takes more than 5 seconds.

P.S.
I believe (once approved) it needs to be back ported to 0.5.x branch as well.
