### PR TITLE
- Paged Table height based on pageSize

### DIFF
--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
@@ -51,6 +51,7 @@ public class PagedTable<T>
         this.dataGrid.setPageSize( pageSize );
         this.pager.setDisplay( dataGrid );
         this.pager.setPageSize( pageSize );
+        this.dataGrid.setHeight((pageSize * 40)+15+"px");
         
     }
 
@@ -61,6 +62,7 @@ public class PagedTable<T>
         this.dataGrid.setPageSize( pageSize );
         this.pager.setDisplay( dataGrid );
         this.pager.setPageSize( pageSize );
+        this.dataGrid.setHeight((pageSize * 40)+15+"px");
     }
     
     
@@ -72,6 +74,7 @@ public class PagedTable<T>
         this.dataGrid.setPageSize( pageSize );
         this.pager.setDisplay( dataGrid );
         this.pager.setPageSize( pageSize );
+        this.dataGrid.setHeight((pageSize * 40)+15+"px");
     }
     
     protected Widget makeWidget() {


### PR DESCRIPTION
This commit calculates the height of the data grid based on the
pageSize variable. Consider this as the first step of changing the
amount of items per page which will change the height of the data grid
accordingly.
Notice that before this all the grids were 300px height, unless it was
override.
