### PR TITLE
BZ-1170679 - Memory leak of UberFireIdentityProvider and other classes i...

### DIFF
--- a/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/BasicAuthSecurityFilter.java
+++ b/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/BasicAuthSecurityFilter.java
@@ -46,18 +46,21 @@ public class BasicAuthSecurityFilter implements Filter {
         final HttpServletResponse response = (HttpServletResponse) _response;
 
         final User user = authenticationService.getUser();
-
-        if ( user == null ) {
-            if ( authenticate( request ) ) {
-                chain.doFilter( request, response );
-                if ( response.isCommitted() ) {
-                    authenticationService.logout();
+        try {
+            if (user == null) {
+                if (authenticate(request)) {
+                    chain.doFilter(request, response);
+                    if (response.isCommitted()) {
+                        authenticationService.logout();
+                    }
+                } else {
+                    challengeClient(request, response);
                 }
             } else {
-                challengeClient( request, response );
+                chain.doFilter(request, response);
             }
-        } else {
-            chain.doFilter( request, response );
+        } finally {
+            request.getSession().invalidate();
         }
     }
 


### PR DESCRIPTION
...n REST interface

invalidate http session on every request to avoid session objects being leftover on the server in case session timeout is set to high value (e.g. kie-wb where session timeout is 24hours)