### PR TITLE
Copy popup test

### DIFF
--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/CopyPopupView.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/CopyPopupView.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.editor.commons.client.file;
+
+import org.uberfire.client.mvp.UberView;
+
+public interface CopyPopupView extends UberView<CopyPopupView.Presenter> {
+
+    public interface Presenter {
+
+        void onCancel();
+
+        void onCopy();
+    }
+
+    String getNewName();
+
+    String getCheckInComment();
+
+    void handleInvalidFileName( String baseFileName );
+
+    void show();
+
+    void hide();
+
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/CopyPopupViewImpl.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/CopyPopupViewImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.editor.commons.client.file;
+
+import com.github.gwtbootstrap.client.ui.TextBox;
+import com.github.gwtbootstrap.client.ui.constants.ButtonType;
+import com.github.gwtbootstrap.client.ui.constants.IconType;
+import com.google.gwt.user.client.Window;
+import org.uberfire.ext.editor.commons.client.resources.CommonImages;
+import org.uberfire.ext.editor.commons.client.resources.i18n.CommonConstants;
+import org.uberfire.ext.widgets.common.client.common.popups.FormStylePopup;
+import org.uberfire.ext.widgets.common.client.common.popups.footers.GenericModalFooter;
+import org.uberfire.mvp.Command;
+
+public class CopyPopupViewImpl extends FormStylePopup implements CopyPopupView {
+
+    private final TextBox nameTextBox = new TextBox();
+    private final TextBox checkInCommentTextBox = new TextBox();
+    private Presenter presenter;
+
+    public CopyPopupViewImpl() {
+        super( CommonImages.INSTANCE.edit(),
+               CommonConstants.INSTANCE.CopyPopupTitle() );
+        //Make sure it appears on top of other popups
+        getElement().getStyle().setZIndex( Integer.MAX_VALUE );
+
+        nameTextBox.setTitle( CommonConstants.INSTANCE.NewName() );
+        nameTextBox.setWidth( "200px" );
+        addAttribute( CommonConstants.INSTANCE.NewNameColon(),
+                      nameTextBox );
+
+        checkInCommentTextBox.setTitle( CommonConstants.INSTANCE.CheckInComment() );
+        checkInCommentTextBox.setWidth( "200px" );
+        addAttribute( CommonConstants.INSTANCE.CheckInCommentColon(),
+                      checkInCommentTextBox );
+        hide();
+
+        GenericModalFooter footer = new GenericModalFooter();
+        footer.addButton( CommonConstants.INSTANCE.CopyPopupCreateACopy(),
+                          new Command() {
+                              @Override
+                              public void execute() {
+                                  presenter.onCopy();
+                              }
+                          },
+                          IconType.SAVE,
+                          ButtonType.PRIMARY );
+        footer.addButton( CommonConstants.INSTANCE.Cancel(),
+                          new Command() {
+                              @Override
+                              public void execute() {
+                                  presenter.onCancel();
+                              }
+                          },
+                          ButtonType.DEFAULT );
+        add( footer );
+    }
+
+    @Override
+    public void init( Presenter presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public String getNewName() {
+        return nameTextBox.getText();
+    }
+
+    @Override
+    public String getCheckInComment() {
+        return checkInCommentTextBox.getText();
+    }
+
+    @Override
+    public void handleInvalidFileName( String baseFileName ) {
+        Window.alert( CommonConstants.INSTANCE.InvalidFileName0( baseFileName ) );
+    }
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderImpl.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderImpl.java
@@ -34,6 +34,7 @@ import org.uberfire.client.mvp.UpdatedLockStatusEvent;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
 import org.uberfire.ext.editor.commons.client.file.CopyPopup;
+import org.uberfire.ext.editor.commons.client.file.CopyPopupViewImpl;
 import org.uberfire.ext.editor.commons.client.file.DeletePopup;
 import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
 import org.uberfire.ext.editor.commons.client.file.RenamePopup;
@@ -214,7 +215,7 @@ public class BasicFileMenuBuilderImpl implements BasicFileMenuBuilder {
                                                                                                                                                       details.getNewFileName(),
                                                                                                                                                       details.getCommitMessage() );
                                                            }
-                                                       } );
+                                                       }, new CopyPopupViewImpl() );
                 popup.show();
             }
         } );
@@ -238,7 +239,7 @@ public class BasicFileMenuBuilderImpl implements BasicFileMenuBuilder {
                                                                                                                                                       details.getNewFileName(),
                                                                                                                                                       details.getCommitMessage() );
                                                            }
-                                                       } );
+                                                       }, new CopyPopupViewImpl() );
                 popup.show();
             }
         } );

--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/CopyPopupTest.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/CopyPopupTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2014 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.editor.commons.client.file;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.client.validation.ValidatorCallback;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class CopyPopupTest {
+
+    private static final String NAME_TEXT = "copy name";
+    private static final String COMMENT_TEXT = "hello world";
+    private static final String PATH = "dir/file.ext";
+
+    private Validator successValidator;
+    private Validator failureValidator;
+
+    @Mock
+    private CopyPopupView view;
+    @Mock
+    private Path path;
+    @Mock
+    private CommandWithFileNameAndCommitMessage command;
+    @Captor
+    private ArgumentCaptor<FileNameAndCommitMessage> msgCaptor;
+
+    @Before
+    public void setUp() {
+
+        // stub mocks
+        when( path.getFileName() ).thenReturn( PATH );
+        when( view.getCheckInComment() ).thenReturn( COMMENT_TEXT );
+        when( view.getNewName() ).thenReturn( NAME_TEXT );
+
+        // set up testing validators
+        // it is easier to set up real objects than stubbing validate() method but we need to spy them
+        // to verify validation was invoked
+        successValidator = spy( new Validator() {
+            @Override
+            public void validate( String value, ValidatorCallback callback ) {
+                callback.onSuccess();
+            }
+        } );
+        failureValidator = spy( new Validator() {
+            @Override
+            public void validate( String value, ValidatorCallback callback ) {
+                callback.onFailure();
+            }
+        } );
+    }
+
+    @Test
+    public void testSuccessfulValidation() {
+        // popup with succesful validation
+        CopyPopup popup = new CopyPopup( path, successValidator, command, view );
+
+        // simulate submitting the popup
+        popup.onCopy();
+
+        // validation was invoked
+        verify( successValidator ).validate( any( String.class ), any( ValidatorCallback.class ) );
+        // command was executed
+        verify( command ).execute( msgCaptor.capture() );
+        // check contents of the message passed to the command
+        assertThat( msgCaptor.getValue().getNewFileName(), CoreMatchers.equalTo( NAME_TEXT ) );
+        assertThat( msgCaptor.getValue().getCommitMessage(), CoreMatchers.equalTo( COMMENT_TEXT ) );
+        // dialog was hidden
+        verify( view ).hide();
+    }
+
+    @Test
+    public void testFailedValidation() {
+        // popup with failing validation
+        CopyPopup popup = new CopyPopup( path, failureValidator, command, view );
+
+        // simulate submitting the popup
+        popup.onCopy();
+
+        // verify validation was invoked
+        verify( failureValidator ).validate( anyString(), any( ValidatorCallback.class ) );
+        // verify command was NOT executed
+        verify( command, never() ).execute( any( FileNameAndCommitMessage.class ) );
+        // popup stays active so that user can correct the input
+        verify( view, never() ).hide();
+        // view handles the failure message
+        verify( view ).handleInvalidFileName( NAME_TEXT );
+    }
+
+    @Test
+    public void testPopupCanceled() {
+        // popup with succesful validation
+        CopyPopup popup = new CopyPopup( path, successValidator, command, view );
+
+        // simulate cancelling the popup
+        popup.onCancel();
+
+        // validation was NOT invoked
+        verify( successValidator, never() ).validate( anyString(), any( ValidatorCallback.class ) );
+        // command was NOT executed
+        verify( command, never() ).execute( any( FileNameAndCommitMessage.class ) );
+        // dialog was hidden
+        verify( view ).hide();
+    }
+
+    @Test
+    public void testDefaultValidator() {
+        // return some crazy values that shouldn't pass any validation
+        when( view.getNewName() ).thenReturn( null );
+        when( view.getCheckInComment() ).thenReturn( null );
+
+        // popup with a default validator
+        CopyPopup popup = new CopyPopup( path, command, view );
+
+        // simulate submitting the popup
+        popup.onCopy();
+
+        // command was executed
+        verify( command ).execute( msgCaptor.capture() );
+        // check contents of the message passed to the command
+        assertThat( msgCaptor.getValue().getNewFileName(), CoreMatchers.nullValue() );
+        assertThat( msgCaptor.getValue().getCommitMessage(), CoreMatchers.nullValue() );
+        // dialog was hidden
+        verify( view ).hide();
+    }
+}

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FormStyleLayout.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FormStyleLayout.java
@@ -73,6 +73,7 @@ public class FormStyleLayout extends Composite implements HasWidgets {
     /**
      * Clears the layout table.
      */
+    @Override
     public void clear() {
         numInLayout = 0;
         this.layout.clear();

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/BaseModal.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/BaseModal.java
@@ -36,18 +36,22 @@ import com.google.gwt.user.client.ui.Widget;
 
 /**
  * Base class for modal popup implementations. Setting the following properties by default:
- * - setMaxHeight( ( Window.getClientHeight() * 0.75 ) + "px" );
- * - setBackdrop( BackdropType.STATIC );
- * - setKeyboard( true );
- * - setAnimation( true );
- * - setDynamicSafe( true );
- * - setHideOthers( false );
+ * <ul>
+ * <li>setMaxHeight( ( Window.getClientHeight() * 0.75 ) + "px" );</li>
+ * <li>setBackdrop( {@link BackdropType#STATIC} );</li>
+ * <li>setKeyboard( true );</li>
+ * <li>setAnimation( true );</li>
+ * <li>setDynamicSafe( true );</li>
+ * <li>setHideOthers( false );</li>
+ * </ul>
  * <p/>
  * Furthermore this Modal provides:
- * - Automatic focus to the first Focusable widget in the body
- * - Automatic invocation of the first Button's ClickHandler where ButtonType==PRIMARY when <enter> is pressed
+ * <ul>
+ * <li>Automatic focus to the first Focusable widget in the body</li>
+ * <li>Automatic invocation of the first Button's ClickHandler where {@link ButtonType}==PRIMARY when &lt;enter&gt; is
+ * pressed</li>
+ * </ul>
  */
-
 public class BaseModal extends Modal {
 
     public BaseModal() {


### PR DESCRIPTION
@mrietveld @ederign please review.

This is improved version of [CopyPopupTest](https://gist.github.com/yurloc/eb8bc92a6c4ee4731c72) from October 2014. I have separated CopyPopup view layer from the presentation logic (following MVP). The code has become more testable. I could avoid most of the hacks I complained about in this [gist](https://gist.github.com/yurloc/eb8bc92a6c4ee4731c72). Strict separation of widgets usage into view prevents any GWT.create() calls during test execution and so GwtMockito is not needed.