### PR TITLE
BZ-1221380: remove use of cookies (that have 4k limit) what, depending

### DIFF
--- a/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/SecurityIntegrationFilter.java
+++ b/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/SecurityIntegrationFilter.java
@@ -3,29 +3,17 @@ package org.uberfire.ext.security.server;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import javax.inject.Inject;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.jboss.errai.marshalling.server.MappingContextSingleton;
-import org.jboss.errai.security.shared.api.UserCookieEncoder;
-import org.jboss.errai.security.shared.api.identity.User;
-import org.jboss.errai.security.shared.service.AuthenticationService;
 
-/**
- * TODO: update me
- */
 public class SecurityIntegrationFilter implements Filter {
-
-    @Inject
-    private AuthenticationService authenticationService;
 
     public static final String PROBE_ROLES_INIT_PARAM = "probe-for-roles";
 
@@ -53,13 +41,6 @@ public class SecurityIntegrationFilter implements Filter {
                           ServletResponse response,
                           FilterChain chain ) throws IOException, ServletException {
         requests.set( (HttpServletRequest) request );
-        final User user = authenticationService.getUser();
-        if ( user != null ) {
-            final Cookie erraiUserCacheCookie = new Cookie(
-                    UserCookieEncoder.USER_COOKIE_NAME,
-                    UserCookieEncoder.toCookieValue( user ) );
-            ( (HttpServletResponse) response ).addCookie( erraiUserCacheCookie );
-        }
         try {
             chain.doFilter( request, response );
         } finally {

--- a/uberfire-wires/uberfire-wires-webapp/src/main/resources/ErraiApp.properties
+++ b/uberfire-wires/uberfire-wires-webapp/src/main/resources/ErraiApp.properties
@@ -31,4 +31,4 @@
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
 
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true

--- a/uberfire-wires/uberfire-wires-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/uberfire-wires/uberfire-wires-webapp/src/main/webapp/WEB-INF/web.xml
@@ -37,6 +37,16 @@
     <url-pattern>/org.uberfire.ext.wires.WiresShowcase/*</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/wires.html</url-pattern>
+  </filter-mapping>
+
   <servlet>
     <!-- NOTE: the integration-test profile uses this web.xml. Integration tests only work properly
 with the DefaultBlockingServlet. If you change this setting, make a backup of this web.xml


### PR DESCRIPTION
of the number of roles/groups of a user, can be reached. new solution
`patches` the host page (UserHostPageFilter) with user's info that now
is supported on errai client security.