### PR TITLE
Provide CopyPopup constructors that don't require view impl

### DIFF
--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/CopyPopup.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/CopyPopup.java
@@ -28,7 +28,25 @@ public class CopyPopup implements CopyPopupView.Presenter {
     private final Validator validator;
     private final CommandWithFileNameAndCommitMessage command;
 
-    public CopyPopup( Path path, CommandWithFileNameAndCommitMessage command, CopyPopupView view ) {
+    public CopyPopup( final Path path,
+                      final CommandWithFileNameAndCommitMessage command ) {
+        this( path,
+              command,
+              new CopyPopupViewImpl() );
+    }
+
+    public CopyPopup( final Path path,
+                      final Validator validator,
+                      final CommandWithFileNameAndCommitMessage command ) {
+        this( path,
+              validator,
+              command,
+              new CopyPopupViewImpl() );
+    }
+
+    public CopyPopup( final Path path,
+                      final CommandWithFileNameAndCommitMessage command,
+                      final CopyPopupView view ) {
         this( path,
               new Validator() {
                   @Override
@@ -37,10 +55,14 @@ public class CopyPopup implements CopyPopupView.Presenter {
                       callback.onSuccess();
                   }
               },
-              command, view );
+              command,
+              view );
     }
 
-    public CopyPopup( Path path, Validator validator, CommandWithFileNameAndCommitMessage command, CopyPopupView view ) {
+    public CopyPopup( final Path path,
+                      final Validator validator,
+                      final CommandWithFileNameAndCommitMessage command,
+                      final CopyPopupView view ) {
         this.validator = checkNotNull( "validator",
                                        validator );
         this.path = checkNotNull( "path",

--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderImpl.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderImpl.java
@@ -34,7 +34,6 @@ import org.uberfire.client.mvp.UpdatedLockStatusEvent;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
 import org.uberfire.ext.editor.commons.client.file.CopyPopup;
-import org.uberfire.ext.editor.commons.client.file.CopyPopupViewImpl;
 import org.uberfire.ext.editor.commons.client.file.DeletePopup;
 import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
 import org.uberfire.ext.editor.commons.client.file.RenamePopup;
@@ -215,7 +214,7 @@ public class BasicFileMenuBuilderImpl implements BasicFileMenuBuilder {
                                                                                                                                                       details.getNewFileName(),
                                                                                                                                                       details.getCommitMessage() );
                                                            }
-                                                       }, new CopyPopupViewImpl() );
+                                                       } );
                 popup.show();
             }
         } );
@@ -239,7 +238,7 @@ public class BasicFileMenuBuilderImpl implements BasicFileMenuBuilder {
                                                                                                                                                       details.getNewFileName(),
                                                                                                                                                       details.getCommitMessage() );
                                                            }
-                                                       }, new CopyPopupViewImpl() );
+                                                       } );
                 popup.show();
             }
         } );


### PR DESCRIPTION
In PR #32 I added constructor parameter which is an undesired API change. This PR returns the original constructors.