### PR TITLE
upgrade to jboss-ip-bom 6.0.0.CR28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with property <version.org.jboss.integration-platform> -->
-    <version>6.0.0.CR27</version>
+    <version>6.0.0.CR28</version>
   </parent>
 
   <groupId>org.uberfire</groupId>

--- a/uberfire-extensions-deps/pom.xml
+++ b/uberfire-extensions-deps/pom.xml
@@ -19,12 +19,12 @@
   </description>
 
   <properties>
-    <version.org.jboss.integration-platform>6.0.0.CR27</version.org.jboss.integration-platform>
+    <version.org.jboss.integration-platform>6.0.0.CR28</version.org.jboss.integration-platform>
     <version.org.jboss.xnio>3.2.0.Final</version.org.jboss.xnio>
     <version.org.eclipse.jgit>3.7.1.201504261725-r</version.org.eclipse.jgit>
-
     <version.org.uberfire>0.7.0-SNAPSHOT</version.org.uberfire>
     <version.org.jboss.errai>3.2.0-SNAPSHOT</version.org.jboss.errai>
+    <version.org.jgroups>3.2.13.Final</version.org.jgroups>
     <version.org.owasp.encoder>1.1</version.org.owasp.encoder>
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
     <version.jakarta-regexp>1.4</version.jakarta-regexp>
@@ -72,6 +72,12 @@
         <type>pom</type>
         <version>${version.org.jboss.errai}</version>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jgroups</groupId>
+        <artifactId>jgroups</artifactId>
+        <version>${version.org.jgroups}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
as uf-e inherits from jboss-ip-bom 6.0.0.CR28 which includes the version 
org.jgroups:jgroups:3.1.14.Final - but this version is not existing on public Nexus whe had to add
org.jgroups:jgroups:3.1.13.Final to UE-deps.
This had to be done if U-ext will upgrade to CR28 and will be there until we found a solution.
