### PR TITLE
Apps perspective does not display names of

### DIFF
--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImpl.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImpl.java
@@ -65,7 +65,13 @@ public class LayoutEditorPluginImpl implements LayoutEditorPlugin {
 
     @Override
     public LayoutTemplate getLayout() {
-        return layoutEditorPresenter.getLayout();
+        return getLayoutEditor();
+    }
+
+    private LayoutTemplate getLayoutEditor() {
+        LayoutTemplate layout = layoutEditorPresenter.getLayout();
+        layout.setName( pluginName );
+        return layout;
     }
 
     @Override
@@ -114,7 +120,7 @@ public class LayoutEditorPluginImpl implements LayoutEditorPlugin {
             public void callback( final String model ) {
                 savePlugin( model, path, saveSuccessCallback );
             }
-        } ).convertLayoutToString(layoutEditorPresenter.getLayout());
+        } ).convertLayoutToString( getLayoutEditor() );
 
     }
 


### PR DESCRIPTION
Apps perspective does not display names of
the apps (BZ1262352)

The name of the layout editor on perspective
editor  was only stored on plugin name
structure (the layout editor name persisted
 was "").