### PR TITLE
UF-228 - Configurable Workbench: Warning about unsaved changes without changing anything

### DIFF
--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
@@ -19,6 +19,18 @@
     <!-- dependencies added because of new illegal transitive dependency check -->
 
     <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-layout-editor-client</artifactId>
     </dependency>

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorPresenter.java
@@ -91,6 +91,7 @@ public class EditorPlugInEditorPresenter
                     }
                 } );
                 view().hideBusyIndicator();
+                setOriginalHash( getContent().hashCode() );
             }
         } ).getPluginContent( versionRecordManager.getCurrentPath() );
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorPresenter.java
@@ -78,37 +78,6 @@ public class EditorPlugInEditorPresenter
         return menus;
     }
 
-    @Override
-    protected void loadContent() {
-        pluginServices.call( new RemoteCallback<PluginContent>() {
-            @Override
-            public void callback( final PluginContent response ) {
-                view().setFramework( response.getFrameworks() );
-                view().setupContent( response, new ParameterizedCommand<Media>() {
-                    @Override
-                    public void execute( final Media media ) {
-                        pluginServices.call().deleteMedia( media );
-                    }
-                } );
-                view().hideBusyIndicator();
-                setOriginalHash( getContent().hashCode() );
-            }
-        } ).getPluginContent( versionRecordManager.getCurrentPath() );
-    }
-
-    protected void save() {
-        new SaveOperationService().save( versionRecordManager.getCurrentPath(),
-                                         new ParameterizedCommand<String>() {
-                                             @Override
-                                             public void execute( final String commitMessage ) {
-                                                 pluginServices.call( getSaveSuccessCallback( getContent().hashCode() ) ).save( getContent(),
-                                                                                                                                commitMessage );
-                                             }
-                                         }
-                                       );
-        concurrentUpdateSessionInfo = null;
-    }
-
     @WorkbenchPartView
     public IsWidget getWidget() {
         return super.baseView;
@@ -116,14 +85,10 @@ public class EditorPlugInEditorPresenter
 
     @OnMayClose
     public boolean onMayClose() {
-        return super.mayClose( getContent().hashCode() );
+        return super.mayClose();
     }
 
-    public PluginSimpleContent getContent() {
-        return new PluginSimpleContent( view().getContent(), view().getTemplate(), view().getCss(), view().getCodeMap(),
-                                        view().getFrameworks(), view().getContent().getLanguage() );
-    }
-
+    @Override
     EditorPlugInEditorView view() {
         return (EditorPlugInEditorView) baseView;
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorView.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorView.java
@@ -65,6 +65,7 @@ public class EditorPlugInEditorView
         htmlPanel.add( editor );
     }
 
+    @Override
     protected void setFramework( final Collection<Framework> frameworks ) {
         if ( frameworks != null && !frameworks.isEmpty() ) {
             final Framework framework = frameworks.iterator().next();
@@ -78,6 +79,7 @@ public class EditorPlugInEditorView
         framework.setSelectedIndex( 0 );
     }
 
+    @Override
     protected Collection<Framework> getFrameworks() {
         if ( framework.getSelectedValue().equalsIgnoreCase( "(Framework)" ) ) {
             return Collections.emptyList();

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseView.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseView.java
@@ -1,21 +1,16 @@
 package org.uberfire.ext.plugin.client.editor;
 
+import java.util.Collection;
 import java.util.Map;
 
 import javax.inject.Inject;
 
 import org.uberfire.ext.editor.commons.client.BaseEditorViewImpl;
 import org.uberfire.ext.plugin.client.widget.plugin.GeneralPluginEditor;
-import org.uberfire.ext.plugin.model.CodeType;
-import org.uberfire.ext.plugin.model.Media;
-import org.uberfire.ext.plugin.model.PluginContent;
-import org.uberfire.ext.plugin.model.PluginSimpleContent;
+import org.uberfire.ext.plugin.model.*;
 import org.uberfire.mvp.ParameterizedCommand;
 
-/**
- * TODO: update me
- */
-public class RuntimePluginBaseView extends BaseEditorViewImpl {
+public abstract class RuntimePluginBaseView extends BaseEditorViewImpl {
 
     @Inject
     protected GeneralPluginEditor editor;
@@ -41,4 +36,7 @@ public class RuntimePluginBaseView extends BaseEditorViewImpl {
         return editor.getCodeMap();
     }
 
+    protected abstract void setFramework( Collection<Framework> frameworks );
+
+    protected abstract Collection<Framework> getFrameworks();
 }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorPresenter.java
@@ -91,6 +91,7 @@ public class ScreenEditorPresenter
                     }
                 } );
                 view().hideBusyIndicator();
+                setOriginalHash( getContent().hashCode() );
             }
         } ).getPluginContent( versionRecordManager.getCurrentPath() );
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorPresenter.java
@@ -78,37 +78,6 @@ public class ScreenEditorPresenter
         return menus;
     }
 
-    @Override
-    protected void loadContent() {
-        pluginServices.call( new RemoteCallback<PluginContent>() {
-            @Override
-            public void callback( final PluginContent response ) {
-                view().setFramework( response.getFrameworks() );
-                view().setupContent( response, new ParameterizedCommand<Media>() {
-                    @Override
-                    public void execute( final Media media ) {
-                        pluginServices.call().deleteMedia( media );
-                    }
-                } );
-                view().hideBusyIndicator();
-                setOriginalHash( getContent().hashCode() );
-            }
-        } ).getPluginContent( versionRecordManager.getCurrentPath() );
-    }
-
-    protected void save() {
-        new SaveOperationService().save( versionRecordManager.getCurrentPath(),
-                                         new ParameterizedCommand<String>() {
-                                             @Override
-                                             public void execute( final String commitMessage ) {
-                                                 pluginServices.call( getSaveSuccessCallback( getContent().hashCode() ) ).save( getContent(),
-                                                                                                                                commitMessage );
-                                             }
-                                         }
-                                       );
-        concurrentUpdateSessionInfo = null;
-    }
-
     @WorkbenchPartView
     public IsWidget getWidget() {
         return super.baseView;
@@ -116,14 +85,11 @@ public class ScreenEditorPresenter
 
     @OnMayClose
     public boolean onMayClose() {
-        return super.mayClose( getContent().hashCode() );
+        return super.mayClose();
     }
 
-    public PluginSimpleContent getContent() {
-        return new PluginSimpleContent( view().getContent(), view().getTemplate(), view().getCss(), view().getCodeMap(),
-                                        view().getFrameworks(), view().getContent().getLanguage() );
-    }
 
+    @Override
     ScreenEditorView view() {
         return (ScreenEditorView) baseView;
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorView.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorView.java
@@ -64,6 +64,7 @@ public class ScreenEditorView
         htmlPanel.add( editor );
     }
 
+    @Override
     protected void setFramework( final Collection<Framework> frameworks ) {
         if ( frameworks != null && !frameworks.isEmpty() ) {
             final Framework framework = frameworks.iterator().next();
@@ -77,6 +78,7 @@ public class ScreenEditorView
         this.framework.setSelectedIndex( 0 );
     }
 
+    @Override
     protected Collection<Framework> getFrameworks() {
         if ( framework.getSelectedValue().equalsIgnoreCase( "(Framework)" ) ) {
             return Collections.emptyList();

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorPresenter.java
@@ -91,6 +91,7 @@ public class SplashEditorPresenter
                     }
                 } );
                 baseView.hideBusyIndicator();
+                setOriginalHash( getContent().hashCode() );
             }
         } ).getPluginContent( versionRecordManager.getCurrentPath() );
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorPresenter.java
@@ -78,37 +78,6 @@ public class SplashEditorPresenter
         return menus;
     }
 
-    @Override
-    protected void loadContent() {
-        pluginServices.call( new RemoteCallback<PluginContent>() {
-            @Override
-            public void callback( final PluginContent response ) {
-                view().setFramework( response.getFrameworks() );
-                view().setupContent( response, new ParameterizedCommand<Media>() {
-                    @Override
-                    public void execute( final Media media ) {
-                        pluginServices.call().deleteMedia( media );
-                    }
-                } );
-                baseView.hideBusyIndicator();
-                setOriginalHash( getContent().hashCode() );
-            }
-        } ).getPluginContent( versionRecordManager.getCurrentPath() );
-    }
-
-    protected void save() {
-        new SaveOperationService().save( versionRecordManager.getCurrentPath(),
-                                         new ParameterizedCommand<String>() {
-                                             @Override
-                                             public void execute( final String commitMessage ) {
-                                                 pluginServices.call( getSaveSuccessCallback( getContent().hashCode() ) ).save( getContent(),
-                                                                                                                                commitMessage );
-                                             }
-                                         }
-                                       );
-        concurrentUpdateSessionInfo = null;
-    }
-
     @WorkbenchPartView
     public IsWidget getWidget() {
         return super.baseView;
@@ -116,14 +85,10 @@ public class SplashEditorPresenter
 
     @OnMayClose
     public boolean onMayClose() {
-        return super.mayClose( getContent().hashCode() );
+        return super.mayClose();
     }
 
-    public PluginSimpleContent getContent() {
-        return new PluginSimpleContent( view().getContent(), view().getTemplate(), view().getCss(), view().getCodeMap(),
-                                        view().getFrameworks(), view().getContent().getLanguage() );
-    }
-
+    @Override
     SplashEditorView view() {
         return (SplashEditorView) baseView;
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorView.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorView.java
@@ -63,6 +63,7 @@ public class SplashEditorView
         htmlPanel.add( editor );
     }
 
+    @Override
     protected void setFramework( final Collection<Framework> frameworks ) {
         if ( frameworks != null && !frameworks.isEmpty() ) {
             final Framework framework = frameworks.iterator().next();
@@ -76,6 +77,7 @@ public class SplashEditorView
         this.framework.setSelectedIndex( 0 );
     }
 
+    @Override
     protected Collection<Framework> getFrameworks() {
         if ( framework.getSelectedValue().equalsIgnoreCase( "(Framework)" ) ) {
             return Collections.emptyList();

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/widget/media/MediaLibraryWidget.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/widget/media/MediaLibraryWidget.java
@@ -40,9 +40,11 @@ import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Caption;
 import org.gwtbootstrap3.client.ui.Column;
+import org.gwtbootstrap3.client.ui.Form;
 import org.gwtbootstrap3.client.ui.Image;
 import org.gwtbootstrap3.client.ui.Row;
 import org.gwtbootstrap3.client.ui.ThumbnailPanel;
+import org.gwtbootstrap3.client.ui.base.form.AbstractForm;
 import org.gwtbootstrap3.client.ui.constants.ColumnSize;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.ImageType;
@@ -53,6 +55,7 @@ import org.uberfire.ext.plugin.event.MediaAdded;
 import org.uberfire.ext.plugin.event.MediaDeleted;
 import org.uberfire.ext.plugin.model.Media;
 import org.uberfire.ext.widgets.common.client.common.FileUpload;
+import org.uberfire.ext.widgets.common.client.common.FileUploadFormEncoder;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 
@@ -67,11 +70,13 @@ public class MediaLibraryWidget extends Composite implements RequiresResize {
 
     private static ViewBinder uiBinder = GWT.create( ViewBinder.class );
 
+    private FileUploadFormEncoder formEncoder = new FileUploadFormEncoder();
+
     @UiField
     FlowPanel content;
 
     @UiField
-    FormPanel form;
+    Form form;
 
     @UiField(provided = true)
     FileUpload fileUpload;
@@ -96,9 +101,11 @@ public class MediaLibraryWidget extends Composite implements RequiresResize {
         form.setEncoding( FormPanel.ENCODING_MULTIPART );
         form.setMethod( FormPanel.METHOD_POST );
 
-        form.addSubmitHandler( new FormPanel.SubmitHandler() {
+        formEncoder.addUtf8Charset( form );
+
+        form.addSubmitHandler( new AbstractForm.SubmitHandler() {
             @Override
-            public void onSubmit( final FormPanel.SubmitEvent event ) {
+            public void onSubmit( final AbstractForm.SubmitEvent event ) {
                 final String fileName = fileUpload.getFilename();
                 if ( isNullOrEmpty( fileName ) ) {
                     event.cancel();
@@ -110,8 +117,9 @@ public class MediaLibraryWidget extends Composite implements RequiresResize {
             }
         } );
 
-        form.addSubmitCompleteHandler( new FormPanel.SubmitCompleteHandler() {
-            public void onSubmitComplete( final FormPanel.SubmitCompleteEvent event ) {
+        form.addSubmitCompleteHandler( new AbstractForm.SubmitCompleteHandler() {
+            @Override
+            public void onSubmitComplete( final AbstractForm.SubmitCompleteEvent event ) {
                 if ( "OK".equalsIgnoreCase( event.getResults() ) ) {
                     Window.alert( "Upload Success" );
                 } else if ( "FAIL".equalsIgnoreCase( event.getResults() ) ) {

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/widget/media/MediaLibraryWidget.ui.xml
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/widget/media/MediaLibraryWidget.ui.xml
@@ -30,9 +30,9 @@
   </ui:style>
 
   <g:FlowPanel ui:field="content">
-    <g:FormPanel ui:field="form" addStyleNames="{style.top-margin}">
+    <b:Form ui:field="form" addStyleNames="{style.top-margin}">
       <c:FileUpload ui:field="fileUpload" name="fileUpload"/>
-    </g:FormPanel>
+    </b:Form>
     <b:Container>
       <b:Row ui:field="library"/>
     </b:Container>

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseEditorTest.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseEditorTest.java
@@ -1,0 +1,100 @@
+package org.uberfire.ext.plugin.client.editor;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.workbench.type.ClientResourceType;
+import org.uberfire.ext.plugin.model.Media;
+import org.uberfire.ext.plugin.model.PluginContent;
+import org.uberfire.ext.plugin.model.PluginSimpleContent;
+import org.uberfire.ext.plugin.model.PluginType;
+import org.uberfire.ext.plugin.service.PluginServices;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mvp.ParameterizedCommand;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class RuntimePluginBaseEditorTest {
+
+    private PluginServices pluginServices;
+    private CallerMock<PluginServices> callerMock;
+    RemoteCallback<PluginContent> successCallBack;
+
+    RuntimePluginBaseView baseEditorView = null;
+
+    private RuntimePluginBaseEditor editor;
+
+    @Before
+    public void setup() {
+        pluginServices = mock( PluginServices.class );
+        callerMock = new CallerMock<PluginServices>( pluginServices );
+        editor = createRuntimePluginBaseEditor();
+        successCallBack = mock( RemoteCallback.class );
+        baseEditorView = mock( RuntimePluginBaseView.class );
+    }
+
+    @Test
+    public void loadContentTest() {
+
+        final PluginContent pluginContent = mock( PluginContent.class );
+        when( pluginServices.getPluginContent( Matchers.<Path>any() ) ).thenReturn( pluginContent );
+
+        assertNull( editor.getOriginalHash() );
+
+        editor.loadContent();
+
+        verify( pluginServices ).getPluginContent( Matchers.<Path>any() );
+        verify( baseEditorView ).setFramework( anyCollection() );
+        verify( baseEditorView ).setupContent( eq(pluginContent), Matchers.<ParameterizedCommand<Media>>any() );
+        verify( baseEditorView ).hideBusyIndicator();
+
+        assertNotNull( editor.getOriginalHash() );
+    }
+
+    private RuntimePluginBaseEditor createRuntimePluginBaseEditor() {
+
+        return new RuntimePluginBaseEditor( baseEditorView ) {
+            @Override
+            protected PluginType getPluginType() {
+                return PluginType.DYNAMIC_MENU;
+            }
+
+            @Override
+            protected ClientResourceType getResourceType() {
+                return null;
+            }
+
+            @Override
+            RuntimePluginBaseView view() {
+                return baseEditorView;
+            }
+
+            @Override
+            Caller<PluginServices> getPluginServices() {
+                return callerMock;
+            }
+
+            @Override
+            ObservablePath getCurrentPath() {
+                return mock( ObservablePath.class );
+            }
+
+            @Override
+            public PluginSimpleContent getContent() {
+                return mock( PluginSimpleContent.class );
+            }
+        };
+
+    }
+
+
+}

--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
@@ -22,12 +22,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.ui.DockLayoutPanel;
 import org.uberfire.client.docks.view.DocksBar;
 import org.uberfire.client.docks.view.DocksBars;
 import org.uberfire.client.workbench.docks.UberfireDock;
@@ -35,6 +35,9 @@ import org.uberfire.client.workbench.docks.UberfireDockPosition;
 import org.uberfire.client.workbench.docks.UberfireDockReadyEvent;
 import org.uberfire.client.workbench.docks.UberfireDocks;
 import org.uberfire.client.workbench.events.PerspectiveChange;
+import org.uberfire.mvp.Command;
+
+import com.google.gwt.user.client.ui.DockLayoutPanel;
 
 @ApplicationScoped
 public class UberfireDocksImpl implements UberfireDocks {
@@ -58,8 +61,8 @@ public class UberfireDocksImpl implements UberfireDocks {
     }
 
     @Override
-    public void setup( DockLayoutPanel rootContainer ) {
-        docksBars.setup( rootContainer );
+    public void setup( DockLayoutPanel rootContainer, Command resizeCommand ) {
+        docksBars.setup( rootContainer, resizeCommand );
         updateDocks();
     }
 

--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
@@ -16,26 +16,27 @@
 
 package org.uberfire.client.docks.view;
 
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.DockLayoutPanel;
-import com.google.gwt.user.client.ui.Widget;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
 import org.uberfire.client.docks.view.bars.DocksCollapsedBar;
 import org.uberfire.client.docks.view.bars.DocksExpandedBar;
 import org.uberfire.client.docks.view.menu.MenuBuilder;
 import org.uberfire.client.mvp.AbstractWorkbenchScreenActivity;
 import org.uberfire.client.mvp.Activity;
-import org.uberfire.client.mvp.ActivityManager;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
+import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.List;
+import com.google.gwt.user.client.ui.DockLayoutPanel;
+import com.google.gwt.user.client.ui.Widget;
 
 @Dependent
 public class DocksBars {
@@ -44,17 +45,16 @@ public class DocksBars {
     private PlaceManager placeManager;
 
     @Inject
-    private ActivityManager activityManager;
-
-    @Inject
     private MenuBuilder menuBuilder;
 
     private List<DocksBar> docks = new ArrayList<DocksBar>();
 
     DockLayoutPanel rootContainer;
+    Command resizeCommand;
 
-    public void setup(DockLayoutPanel rootContainer) {
+    public void setup(DockLayoutPanel rootContainer, Command resizeCommand) {
         this.rootContainer = rootContainer;
+        this.resizeCommand = resizeCommand;
         for (UberfireDockPosition uberfireDockPosition : UberfireDockPosition.values()) {
             createDock(uberfireDockPosition);
         }
@@ -164,7 +164,7 @@ public class DocksBars {
         rootContainer.setWidgetHidden(docksBar.getDockResizeBar(), true);
     }
 
-    private void collapse(Widget bar) {
+    void collapse(Widget bar) {
         rootContainer.setWidgetHidden(bar, true);
     }
 
@@ -174,7 +174,7 @@ public class DocksBars {
         collapse(dockBar);
     }
 
-    private ParameterizedCommand<String> createDockSelectCommand(final UberfireDock targetDock, final DocksBar docksBar) {
+    ParameterizedCommand<String> createDockSelectCommand(final UberfireDock targetDock, final DocksBar docksBar) {
         return new ParameterizedCommand<String>() {
             @Override
             public void execute(String clickDockName) {
@@ -183,12 +183,13 @@ public class DocksBars {
                     if (docksBar.isCollapsedBarInSingleMode()) {
                         collapse(docksBar.getCollapsedBar());
                     }
+                    resizeCommand.execute();
                 }
             }
         };
     }
 
-    private void selectDock(UberfireDock targetDock,
+    void selectDock(UberfireDock targetDock,
                             DocksBar docksBar) {
         DocksCollapsedBar collapsedBar = docksBar.getCollapsedBar();
         DocksExpandedBar expandedBar = docksBar.getExpandedBar();
@@ -225,7 +226,7 @@ public class DocksBars {
         expandedBar.setup(targetDock.getLabel(), createDockDeselectCommand(targetDock, docksBar));
     }
 
-    private ParameterizedCommand<String> createDockDeselectCommand(final UberfireDock targetDock, final DocksBar docksBar) {
+    ParameterizedCommand<String> createDockDeselectCommand(final UberfireDock targetDock, final DocksBar docksBar) {
         return new ParameterizedCommand<String>() {
             @Override
             public void execute(String clickDockName) {
@@ -234,12 +235,13 @@ public class DocksBars {
                     if (docksBar.isCollapsedBarInSingleMode()) {
                         expand(docksBar.getCollapsedBar());
                     }
+                    resizeCommand.execute();
                 }
             }
         };
     }
 
-    private void deselectDock(DocksBar docksBar) {
+    void deselectDock(DocksBar docksBar) {
         DocksCollapsedBar collapsedBar = docksBar.getCollapsedBar();
         DocksExpandedBar dockExpandedBar = docksBar.getExpandedBar();
 
@@ -286,7 +288,7 @@ public class DocksBars {
         return rootContainer != null;
     }
 
-    private void expand(Widget dock) {
+    void expand(Widget dock) {
         rootContainer.setWidgetHidden(dock, false);
     }
 

--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/UberfireDocksImplTest.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/UberfireDocksImplTest.java
@@ -16,13 +16,18 @@
 
 package org.uberfire.client.docks;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gwt.user.client.ui.DockLayoutPanel;
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,11 +37,12 @@ import org.uberfire.client.docks.view.DocksBars;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 import org.uberfire.client.workbench.events.PerspectiveChange;
+import org.uberfire.mvp.Command;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.workbench.model.toolbar.IconType;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import com.google.gwt.user.client.ui.DockLayoutPanel;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class UberfireDocksImplTest {
@@ -48,6 +54,7 @@ public class UberfireDocksImplTest {
     private DockLayoutPanel dockLayoutPanel;
 
     private UberfireDocksImpl uberfireDocks;
+    private Command resizeCommand;
 
 
     private final String SOME_PERSPECTIVE = "SomePerspective";
@@ -67,12 +74,17 @@ public class UberfireDocksImplTest {
             protected void fireEvent() {
             }
         };
+        resizeCommand = new Command() {
+            @Override
+            public void execute() {
+            }
+        };
     }
 
     @Test
     public void setupDocks() {
-        uberfireDocks.setup(dockLayoutPanel);
-        verify(docksBars).setup(dockLayoutPanel);
+        uberfireDocks.setup(dockLayoutPanel, resizeCommand);
+        verify(docksBars).setup(dockLayoutPanel, resizeCommand);
     }
 
     @Test

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FileUploadFormEncoder.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FileUploadFormEncoder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.uberfire.ext.widgets.common.client.common;
+
+import org.gwtbootstrap3.client.ui.Form;
+
+import com.google.gwt.dom.client.FormElement;
+import com.google.gwt.user.client.ui.Hidden;
+
+public class FileUploadFormEncoder {
+
+    /**
+     * Sets the encoding of the provided form to UTF-8, see
+     * https://code.google.com/p/google-web-toolkit/issues/detail?id=4682 for
+     * details.
+     * 
+     * @param form
+     */
+    public void addUtf8Charset( final Form form ) {
+        FormElement.as( form.getElement() ).setAcceptCharset( "UTF-8" );
+
+        final Hidden field = new Hidden();
+        field.setName( "utf8char" );
+        field.setValue( "\u8482" );
+        form.add( field );
+    }
+}

--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
@@ -96,6 +96,12 @@
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadTest.java
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.uberfire.ext.widgets.core.client.editors.defaulteditor;
+
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.Form;
+import org.gwtbootstrap3.client.ui.base.form.AbstractForm.SubmitCompleteHandler;
+import org.gwtbootstrap3.client.ui.base.form.AbstractForm.SubmitHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.ext.widgets.common.client.common.FileUploadFormEncoder;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class DefaultEditorFileUploadTest {
+
+    @InjectMocks
+    private FileUploadEditor editor;
+
+    @GwtMock
+    private Form form;
+
+    @Mock
+    private FileUploadFormEncoder formEncoder;
+
+    @Before
+    public void setup() {
+        editor.forceInitForm();
+    }
+
+    @Test
+    public void formCharsetAdded() {
+        verify( formEncoder, times( 1 ) ).addUtf8Charset( form );
+    }
+
+    @Test
+    public void formSubmitHandlersSet() {
+        verify( form, times( 1 ) ).addSubmitHandler( any( SubmitHandler.class ) );
+        verify( form, times( 1 ) ).addSubmitCompleteHandler( any( SubmitCompleteHandler.class ) );
+    }
+
+}

--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/FileUploadEditor.java
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/FileUploadEditor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.uberfire.ext.widgets.core.client.editors.defaulteditor;
+
+import java.util.Map;
+
+public class FileUploadEditor extends DefaultEditorFileUploadBase {
+
+    boolean initialized;
+
+    public FileUploadEditor() {
+        super( false );
+    }
+
+    @Override
+    void initForm() {
+        if ( initialized ) {
+            super.initForm();
+        }
+    }
+
+    void forceInitForm() {
+        this.initialized = true;
+        initForm();
+    }
+
+    @Override
+    protected Map<String, String> getParameters() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
On Configurable workbench, when you open a SplashScreens/Screens/Editors even when you don't change anything, the warning about unsaved changes are displayed.

We have to set originalHash on Base editor when SplashScreens/Screens/Editors  are loaded because:

        @OnMayClose
        public boolean mayClose( Integer currentHash ) {
        if ( isDirty( currentHash ) ) {
            return baseView.confirmClose();
        } else {
            return true;
        }
    }

    public boolean isDirty( Integer currentHash ) {
        if ( originalHash == null ) {
            return currentHash != null;
        } else {
            return !originalHash.equals( currentHash );
        }
    }
