### PR TITLE
Fixed UF-230: Adding/Removing docks can cause incorrect workbench layout 

### DIFF
--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
@@ -22,12 +22,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.ui.DockLayoutPanel;
 import org.uberfire.client.docks.view.DocksBar;
 import org.uberfire.client.docks.view.DocksBars;
 import org.uberfire.client.workbench.docks.UberfireDock;
@@ -35,6 +35,9 @@ import org.uberfire.client.workbench.docks.UberfireDockPosition;
 import org.uberfire.client.workbench.docks.UberfireDockReadyEvent;
 import org.uberfire.client.workbench.docks.UberfireDocks;
 import org.uberfire.client.workbench.events.PerspectiveChange;
+import org.uberfire.mvp.Command;
+
+import com.google.gwt.user.client.ui.DockLayoutPanel;
 
 @ApplicationScoped
 public class UberfireDocksImpl implements UberfireDocks {
@@ -58,8 +61,8 @@ public class UberfireDocksImpl implements UberfireDocks {
     }
 
     @Override
-    public void setup( DockLayoutPanel rootContainer ) {
-        docksBars.setup( rootContainer );
+    public void setup( DockLayoutPanel rootContainer, Command resizeCommand ) {
+        docksBars.setup( rootContainer, resizeCommand );
         updateDocks();
     }
 

--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
@@ -16,26 +16,27 @@
 
 package org.uberfire.client.docks.view;
 
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.DockLayoutPanel;
-import com.google.gwt.user.client.ui.Widget;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
 import org.uberfire.client.docks.view.bars.DocksCollapsedBar;
 import org.uberfire.client.docks.view.bars.DocksExpandedBar;
 import org.uberfire.client.docks.view.menu.MenuBuilder;
 import org.uberfire.client.mvp.AbstractWorkbenchScreenActivity;
 import org.uberfire.client.mvp.Activity;
-import org.uberfire.client.mvp.ActivityManager;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
+import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.List;
+import com.google.gwt.user.client.ui.DockLayoutPanel;
+import com.google.gwt.user.client.ui.Widget;
 
 @Dependent
 public class DocksBars {
@@ -44,17 +45,16 @@ public class DocksBars {
     private PlaceManager placeManager;
 
     @Inject
-    private ActivityManager activityManager;
-
-    @Inject
     private MenuBuilder menuBuilder;
 
     private List<DocksBar> docks = new ArrayList<DocksBar>();
 
     DockLayoutPanel rootContainer;
+    Command resizeCommand;
 
-    public void setup(DockLayoutPanel rootContainer) {
+    public void setup(DockLayoutPanel rootContainer, Command resizeCommand) {
         this.rootContainer = rootContainer;
+        this.resizeCommand = resizeCommand;
         for (UberfireDockPosition uberfireDockPosition : UberfireDockPosition.values()) {
             createDock(uberfireDockPosition);
         }
@@ -164,7 +164,7 @@ public class DocksBars {
         rootContainer.setWidgetHidden(docksBar.getDockResizeBar(), true);
     }
 
-    private void collapse(Widget bar) {
+    void collapse(Widget bar) {
         rootContainer.setWidgetHidden(bar, true);
     }
 
@@ -174,7 +174,7 @@ public class DocksBars {
         collapse(dockBar);
     }
 
-    private ParameterizedCommand<String> createDockSelectCommand(final UberfireDock targetDock, final DocksBar docksBar) {
+    ParameterizedCommand<String> createDockSelectCommand(final UberfireDock targetDock, final DocksBar docksBar) {
         return new ParameterizedCommand<String>() {
             @Override
             public void execute(String clickDockName) {
@@ -183,12 +183,13 @@ public class DocksBars {
                     if (docksBar.isCollapsedBarInSingleMode()) {
                         collapse(docksBar.getCollapsedBar());
                     }
+                    resizeCommand.execute();
                 }
             }
         };
     }
 
-    private void selectDock(UberfireDock targetDock,
+    void selectDock(UberfireDock targetDock,
                             DocksBar docksBar) {
         DocksCollapsedBar collapsedBar = docksBar.getCollapsedBar();
         DocksExpandedBar expandedBar = docksBar.getExpandedBar();
@@ -225,7 +226,7 @@ public class DocksBars {
         expandedBar.setup(targetDock.getLabel(), createDockDeselectCommand(targetDock, docksBar));
     }
 
-    private ParameterizedCommand<String> createDockDeselectCommand(final UberfireDock targetDock, final DocksBar docksBar) {
+    ParameterizedCommand<String> createDockDeselectCommand(final UberfireDock targetDock, final DocksBar docksBar) {
         return new ParameterizedCommand<String>() {
             @Override
             public void execute(String clickDockName) {
@@ -234,12 +235,13 @@ public class DocksBars {
                     if (docksBar.isCollapsedBarInSingleMode()) {
                         expand(docksBar.getCollapsedBar());
                     }
+                    resizeCommand.execute();
                 }
             }
         };
     }
 
-    private void deselectDock(DocksBar docksBar) {
+    void deselectDock(DocksBar docksBar) {
         DocksCollapsedBar collapsedBar = docksBar.getCollapsedBar();
         DocksExpandedBar dockExpandedBar = docksBar.getExpandedBar();
 
@@ -286,7 +288,7 @@ public class DocksBars {
         return rootContainer != null;
     }
 
-    private void expand(Widget dock) {
+    void expand(Widget dock) {
         rootContainer.setWidgetHidden(dock, false);
     }
 

--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/UberfireDocksImplTest.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/UberfireDocksImplTest.java
@@ -16,13 +16,18 @@
 
 package org.uberfire.client.docks;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gwt.user.client.ui.DockLayoutPanel;
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,11 +37,12 @@ import org.uberfire.client.docks.view.DocksBars;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 import org.uberfire.client.workbench.events.PerspectiveChange;
+import org.uberfire.mvp.Command;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.workbench.model.toolbar.IconType;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import com.google.gwt.user.client.ui.DockLayoutPanel;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class UberfireDocksImplTest {
@@ -48,6 +54,7 @@ public class UberfireDocksImplTest {
     private DockLayoutPanel dockLayoutPanel;
 
     private UberfireDocksImpl uberfireDocks;
+    private Command resizeCommand;
 
 
     private final String SOME_PERSPECTIVE = "SomePerspective";
@@ -67,12 +74,17 @@ public class UberfireDocksImplTest {
             protected void fireEvent() {
             }
         };
+        resizeCommand = new Command() {
+            @Override
+            public void execute() {
+            }
+        };
     }
 
     @Test
     public void setupDocks() {
-        uberfireDocks.setup(dockLayoutPanel);
-        verify(docksBars).setup(dockLayoutPanel);
+        uberfireDocks.setup(dockLayoutPanel, resizeCommand);
+        verify(docksBars).setup(dockLayoutPanel, resizeCommand);
     }
 
     @Test


### PR DESCRIPTION
Adding/Removing docks needs to trigger resizing of the workbench layout so that other components can adjust their size accordingly.