### PR TITLE
Add no argument constructor to client-side application-scoped bean

### DIFF
--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
@@ -55,6 +55,10 @@ public class UberfireDocksImpl implements UberfireDocks {
     @Inject
     private Event<UberfireDockReadyEvent> dockReadyEvent;
 
+    // For proxying
+    public UberfireDocksImpl() {
+    }
+
     @Inject
     public UberfireDocksImpl( DocksBars docksBars ) {
         this.docksBars = docksBars;


### PR DESCRIPTION
This change helps prepare Uberfire for Errai 4.0, where normal scope beans will have to be proxiable.