### PR TITLE
UF-228 - Configurable Workbench: Warning about unsaved changes without changing anything

### DIFF
--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
@@ -19,6 +19,18 @@
     <!-- dependencies added because of new illegal transitive dependency check -->
 
     <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-layout-editor-client</artifactId>
     </dependency>

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorPresenter.java
@@ -78,36 +78,6 @@ public class EditorPlugInEditorPresenter
         return menus;
     }
 
-    @Override
-    protected void loadContent() {
-        pluginServices.call( new RemoteCallback<PluginContent>() {
-            @Override
-            public void callback( final PluginContent response ) {
-                view().setFramework( response.getFrameworks() );
-                view().setupContent( response, new ParameterizedCommand<Media>() {
-                    @Override
-                    public void execute( final Media media ) {
-                        pluginServices.call().deleteMedia( media );
-                    }
-                } );
-                view().hideBusyIndicator();
-            }
-        } ).getPluginContent( versionRecordManager.getCurrentPath() );
-    }
-
-    protected void save() {
-        new SaveOperationService().save( versionRecordManager.getCurrentPath(),
-                                         new ParameterizedCommand<String>() {
-                                             @Override
-                                             public void execute( final String commitMessage ) {
-                                                 pluginServices.call( getSaveSuccessCallback( getContent().hashCode() ) ).save( getContent(),
-                                                                                                                                commitMessage );
-                                             }
-                                         }
-                                       );
-        concurrentUpdateSessionInfo = null;
-    }
-
     @WorkbenchPartView
     public IsWidget getWidget() {
         return super.baseView;
@@ -115,14 +85,10 @@ public class EditorPlugInEditorPresenter
 
     @OnMayClose
     public boolean onMayClose() {
-        return super.mayClose( getContent().hashCode() );
+        return super.mayClose();
     }
 
-    public PluginSimpleContent getContent() {
-        return new PluginSimpleContent( view().getContent(), view().getTemplate(), view().getCss(), view().getCodeMap(),
-                                        view().getFrameworks(), view().getContent().getLanguage() );
-    }
-
+    @Override
     EditorPlugInEditorView view() {
         return (EditorPlugInEditorView) baseView;
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorView.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/EditorPlugInEditorView.java
@@ -65,6 +65,7 @@ public class EditorPlugInEditorView
         htmlPanel.add( editor );
     }
 
+    @Override
     protected void setFramework( final Collection<Framework> frameworks ) {
         if ( frameworks != null && !frameworks.isEmpty() ) {
             final Framework framework = frameworks.iterator().next();
@@ -78,6 +79,7 @@ public class EditorPlugInEditorView
         framework.setSelectedIndex( 0 );
     }
 
+    @Override
     protected Collection<Framework> getFrameworks() {
         if ( framework.getSelectedValue().equalsIgnoreCase( "(Framework)" ) ) {
             return Collections.emptyList();

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseView.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseView.java
@@ -1,21 +1,16 @@
 package org.uberfire.ext.plugin.client.editor;
 
+import java.util.Collection;
 import java.util.Map;
 
 import javax.inject.Inject;
 
 import org.uberfire.ext.editor.commons.client.BaseEditorViewImpl;
 import org.uberfire.ext.plugin.client.widget.plugin.GeneralPluginEditor;
-import org.uberfire.ext.plugin.model.CodeType;
-import org.uberfire.ext.plugin.model.Media;
-import org.uberfire.ext.plugin.model.PluginContent;
-import org.uberfire.ext.plugin.model.PluginSimpleContent;
+import org.uberfire.ext.plugin.model.*;
 import org.uberfire.mvp.ParameterizedCommand;
 
-/**
- * TODO: update me
- */
-public class RuntimePluginBaseView extends BaseEditorViewImpl {
+public abstract class RuntimePluginBaseView extends BaseEditorViewImpl {
 
     @Inject
     protected GeneralPluginEditor editor;
@@ -41,4 +36,7 @@ public class RuntimePluginBaseView extends BaseEditorViewImpl {
         return editor.getCodeMap();
     }
 
+    protected abstract void setFramework( Collection<Framework> frameworks );
+
+    protected abstract Collection<Framework> getFrameworks();
 }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorPresenter.java
@@ -78,36 +78,6 @@ public class ScreenEditorPresenter
         return menus;
     }
 
-    @Override
-    protected void loadContent() {
-        pluginServices.call( new RemoteCallback<PluginContent>() {
-            @Override
-            public void callback( final PluginContent response ) {
-                view().setFramework( response.getFrameworks() );
-                view().setupContent( response, new ParameterizedCommand<Media>() {
-                    @Override
-                    public void execute( final Media media ) {
-                        pluginServices.call().deleteMedia( media );
-                    }
-                } );
-                view().hideBusyIndicator();
-            }
-        } ).getPluginContent( versionRecordManager.getCurrentPath() );
-    }
-
-    protected void save() {
-        new SaveOperationService().save( versionRecordManager.getCurrentPath(),
-                                         new ParameterizedCommand<String>() {
-                                             @Override
-                                             public void execute( final String commitMessage ) {
-                                                 pluginServices.call( getSaveSuccessCallback( getContent().hashCode() ) ).save( getContent(),
-                                                                                                                                commitMessage );
-                                             }
-                                         }
-                                       );
-        concurrentUpdateSessionInfo = null;
-    }
-
     @WorkbenchPartView
     public IsWidget getWidget() {
         return super.baseView;
@@ -115,14 +85,11 @@ public class ScreenEditorPresenter
 
     @OnMayClose
     public boolean onMayClose() {
-        return super.mayClose( getContent().hashCode() );
+        return super.mayClose();
     }
 
-    public PluginSimpleContent getContent() {
-        return new PluginSimpleContent( view().getContent(), view().getTemplate(), view().getCss(), view().getCodeMap(),
-                                        view().getFrameworks(), view().getContent().getLanguage() );
-    }
 
+    @Override
     ScreenEditorView view() {
         return (ScreenEditorView) baseView;
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorView.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/ScreenEditorView.java
@@ -64,6 +64,7 @@ public class ScreenEditorView
         htmlPanel.add( editor );
     }
 
+    @Override
     protected void setFramework( final Collection<Framework> frameworks ) {
         if ( frameworks != null && !frameworks.isEmpty() ) {
             final Framework framework = frameworks.iterator().next();
@@ -77,6 +78,7 @@ public class ScreenEditorView
         this.framework.setSelectedIndex( 0 );
     }
 
+    @Override
     protected Collection<Framework> getFrameworks() {
         if ( framework.getSelectedValue().equalsIgnoreCase( "(Framework)" ) ) {
             return Collections.emptyList();

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorPresenter.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorPresenter.java
@@ -78,36 +78,6 @@ public class SplashEditorPresenter
         return menus;
     }
 
-    @Override
-    protected void loadContent() {
-        pluginServices.call( new RemoteCallback<PluginContent>() {
-            @Override
-            public void callback( final PluginContent response ) {
-                view().setFramework( response.getFrameworks() );
-                view().setupContent( response, new ParameterizedCommand<Media>() {
-                    @Override
-                    public void execute( final Media media ) {
-                        pluginServices.call().deleteMedia( media );
-                    }
-                } );
-                baseView.hideBusyIndicator();
-            }
-        } ).getPluginContent( versionRecordManager.getCurrentPath() );
-    }
-
-    protected void save() {
-        new SaveOperationService().save( versionRecordManager.getCurrentPath(),
-                                         new ParameterizedCommand<String>() {
-                                             @Override
-                                             public void execute( final String commitMessage ) {
-                                                 pluginServices.call( getSaveSuccessCallback( getContent().hashCode() ) ).save( getContent(),
-                                                                                                                                commitMessage );
-                                             }
-                                         }
-                                       );
-        concurrentUpdateSessionInfo = null;
-    }
-
     @WorkbenchPartView
     public IsWidget getWidget() {
         return super.baseView;
@@ -115,14 +85,10 @@ public class SplashEditorPresenter
 
     @OnMayClose
     public boolean onMayClose() {
-        return super.mayClose( getContent().hashCode() );
+        return super.mayClose();
     }
 
-    public PluginSimpleContent getContent() {
-        return new PluginSimpleContent( view().getContent(), view().getTemplate(), view().getCss(), view().getCodeMap(),
-                                        view().getFrameworks(), view().getContent().getLanguage() );
-    }
-
+    @Override
     SplashEditorView view() {
         return (SplashEditorView) baseView;
     }

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorView.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/SplashEditorView.java
@@ -63,6 +63,7 @@ public class SplashEditorView
         htmlPanel.add( editor );
     }
 
+    @Override
     protected void setFramework( final Collection<Framework> frameworks ) {
         if ( frameworks != null && !frameworks.isEmpty() ) {
             final Framework framework = frameworks.iterator().next();
@@ -76,6 +77,7 @@ public class SplashEditorView
         this.framework.setSelectedIndex( 0 );
     }
 
+    @Override
     protected Collection<Framework> getFrameworks() {
         if ( framework.getSelectedValue().equalsIgnoreCase( "(Framework)" ) ) {
             return Collections.emptyList();

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseEditorTest.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseEditorTest.java
@@ -1,0 +1,100 @@
+package org.uberfire.ext.plugin.client.editor;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.workbench.type.ClientResourceType;
+import org.uberfire.ext.plugin.model.Media;
+import org.uberfire.ext.plugin.model.PluginContent;
+import org.uberfire.ext.plugin.model.PluginSimpleContent;
+import org.uberfire.ext.plugin.model.PluginType;
+import org.uberfire.ext.plugin.service.PluginServices;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mvp.ParameterizedCommand;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class RuntimePluginBaseEditorTest {
+
+    private PluginServices pluginServices;
+    private CallerMock<PluginServices> callerMock;
+    RemoteCallback<PluginContent> successCallBack;
+
+    RuntimePluginBaseView baseEditorView = null;
+
+    private RuntimePluginBaseEditor editor;
+
+    @Before
+    public void setup() {
+        pluginServices = mock( PluginServices.class );
+        callerMock = new CallerMock<PluginServices>( pluginServices );
+        editor = createRuntimePluginBaseEditor();
+        successCallBack = mock( RemoteCallback.class );
+        baseEditorView = mock( RuntimePluginBaseView.class );
+    }
+
+    @Test
+    public void loadContentTest() {
+
+        final PluginContent pluginContent = mock( PluginContent.class );
+        when( pluginServices.getPluginContent( Matchers.<Path>any() ) ).thenReturn( pluginContent );
+
+        assertNull( editor.getOriginalHash() );
+
+        editor.loadContent();
+
+        verify( pluginServices ).getPluginContent( Matchers.<Path>any() );
+        verify( baseEditorView ).setFramework( anyCollection() );
+        verify( baseEditorView ).setupContent( eq(pluginContent), Matchers.<ParameterizedCommand<Media>>any() );
+        verify( baseEditorView ).hideBusyIndicator();
+
+        assertNotNull( editor.getOriginalHash() );
+    }
+
+    private RuntimePluginBaseEditor createRuntimePluginBaseEditor() {
+
+        return new RuntimePluginBaseEditor( baseEditorView ) {
+            @Override
+            protected PluginType getPluginType() {
+                return PluginType.DYNAMIC_MENU;
+            }
+
+            @Override
+            protected ClientResourceType getResourceType() {
+                return null;
+            }
+
+            @Override
+            RuntimePluginBaseView view() {
+                return baseEditorView;
+            }
+
+            @Override
+            Caller<PluginServices> getPluginServices() {
+                return callerMock;
+            }
+
+            @Override
+            ObservablePath getCurrentPath() {
+                return mock( ObservablePath.class );
+            }
+
+            @Override
+            public PluginSimpleContent getContent() {
+                return mock( PluginSimpleContent.class );
+            }
+        };
+
+    }
+
+
+}


### PR DESCRIPTION
This is a updated version of: https://github.com/uberfire/uberfire-extensions/pull/75

Updates
======
Add a Refactoring removing duplicated logic from editors and moving to super class (as @csadilek requested).
Also adding coverage to load content method.

PR-75
=====
On Configurable workbench, when you open a SplashScreens/Screens/Editors even when you don't change anything, the warning about unsaved changes are displayed.

We have to set originalHash on Base editor when SplashScreens/Screens/Editors  are loaded because:

        @OnMayClose
        public boolean mayClose( Integer currentHash ) {
        if ( isDirty( currentHash ) ) {
            return baseView.confirmClose();
        } else {
            return true;
        }
    }

    public boolean isDirty( Integer currentHash ) {
        if ( originalHash == null ) {
            return currentHash != null;
        } else {
            return !originalHash.equals( currentHash );
        }
    }
