### PR TITLE
Fix for UF-227: Dock resize doesn't trigger workbench layout resize

### DIFF
--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
@@ -117,12 +117,13 @@ public class DocksBars {
                     docksBar.setExpandedSize(size);
                     rootContainer.setWidgetSize(docksBar.getExpandedBar(), docksBar.getExpandedBarSize());
                     docksBar.getExpandedBar().setupDockContentSize();
+                    resizeCommand.execute();
                 }
             }
         };
     }
 
-    private boolean sizeIsValid(Double size, DocksBar docksBar) {
+    boolean sizeIsValid(Double size, DocksBar docksBar) {
         int max = calculateMaxSize(docksBar);
         int minVisibleSize = 1;
         return size > minVisibleSize && size < max;

--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/DocksBarsTest.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/DocksBarsTest.java
@@ -216,6 +216,24 @@ public class DocksBarsTest {
         verify( resizeCommand ).execute();
         verify( docksBarsSpy ).expand( dockBar.getCollapsedBar() );
     }
+    
+    @Test
+    public void dockResizeCommand() {
+        final double simulatedSize = 0d;
+        final DocksBars docksBarsSpy = spy( docksBars );
+
+        docksBarsSpy.setup( dockLayoutPanel,resizeCommand );
+        docksBarsSpy.addDock( dock0 );
+
+        Mockito.doReturn( true ).when( docksBarsSpy ).sizeIsValid( any( Double.class ), any( DocksBar.class ) );
+        
+        final DocksBar dockBar = spy( docksBars.getDockBar( dock0 ) );
+        ParameterizedCommand<Double> dockResizeCommand = docksBarsSpy.createResizeCommand( dockBar );
+
+        dockResizeCommand.execute( simulatedSize );
+        verify( dockBar ).setExpandedSize( simulatedSize );
+        verify( resizeCommand ).execute();
+    }
 
     private DocksBar createDocksBarMock() {
         DocksBar mock = mock(DocksBar.class);


### PR DESCRIPTION
- After applying UF-227 on master resizing the project explorer
no longer resized maximized editors

- This fix is also related to UF-230