### PR TITLE
BZ:1265600 - WAS: ClassNotFoundException: org.uberfire.ext.widgets.co…

### DIFF
--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/popup/DataGridFilterSummary.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/popup/DataGridFilterSummary.java
@@ -6,7 +6,6 @@ import org.uberfire.paging.AbstractPageRow;
 import java.io.Serializable;
 
 
-@Portable
 public class DataGridFilterSummary extends AbstractPageRow implements Serializable {
 
     private String filterName;


### PR DESCRIPTION
…mmon.client.tables.popup.DataGridFilterSummary

To avoid error message for using the annotation @portable