### PR TITLE
UF-227: More dock resize fixes (see below)

### DIFF
--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
@@ -35,6 +35,8 @@ import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -173,6 +175,18 @@ public class DocksBars {
         DocksBar dockBar = getDockBar(position);
         dockBar.clearAll();
         collapse(dockBar);
+        
+        resizeDeferred();
+    }
+    
+    void resizeDeferred() {
+        Scheduler.get().scheduleDeferred( new ScheduledCommand() {
+
+            @Override
+            public void execute() {
+                resizeCommand.execute();
+            }
+        } );
     }
 
     ParameterizedCommand<String> createDockSelectCommand(final UberfireDock targetDock, final DocksBar docksBar) {

--- a/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/DocksBarsTest.java
+++ b/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/DocksBarsTest.java
@@ -119,7 +119,21 @@ public class DocksBarsTest {
         verify(dock2).clearAll();
         //2 for each dock(collapsed/expanded/resize)
         verify(dockLayoutPanel, times(6)).setWidgetHidden(any(Widget.class), eq(true));
+    }
+    
+    @Test
+    public void clearAndCollapse() {
 
+        docksBars.setup(dockLayoutPanel, resizeCommand);
+        DocksBars docksBarsSpy = spy(docksBars);
+        DocksBar dock1 = createDocksBarMock();
+        when(docksBarsSpy.getDockBar(UberfireDockPosition.EAST)).thenReturn(dock1);
+
+        docksBarsSpy.clearAndCollapse( UberfireDockPosition.EAST );
+
+        verify(dock1).clearAll();
+        verify(docksBarsSpy).resizeDeferred();
+        verify(dockLayoutPanel, times(3)).setWidgetHidden(any(Widget.class), eq(true));
     }
 
     @Test


### PR DESCRIPTION
This fixes the following two issues:

- When opening an editor with east docks (i.e. data modeller) the
editor's initial horizontal size is incorrect (it's too wide and
part of its content is hidden behind the docks)

- When switching to the source tab after expanding a dock, the
source view isn't properly resized and is limiting its horizontal
size by the width of the dock that is no longer displayed