### PR TITLE
UF-238: Configurable Workbench: Drag and drop does not work on IE11

### DIFF
--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DndData.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DndData.java
@@ -1,0 +1,59 @@
+/*
+* Copyright 2015 JBoss Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.uberfire.ext.layout.editor.client.dnd;
+
+import com.google.gwt.event.dom.client.DropEvent;
+import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+
+
+public class DndData {
+
+    //ie11 requires that on a dnd event, the DataTransfer format is exactly "text"
+    public static final String FORMAT = "text";
+    private static final String SEPARATOR = "@";
+
+    public static String generateData( LayoutDragComponent type ) {
+        if ( type instanceof GridLayoutDragComponent ) {
+            return prepareData( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT, ( ( GridLayoutDragComponent ) type ).label() );
+        } else {
+            return prepareData( LayoutDragComponent.class.toString(), type.getClass().getName() );
+        }
+    }
+
+    static String prepareData( String eventType, String eventData ) {
+        return eventType + SEPARATOR + eventData;
+    }
+
+
+    public static String getEventType( DropEvent event ) {
+        final String data = event.getData( FORMAT );
+        final String[] split = data.split( SEPARATOR );
+        if ( split.length > 0 ) {
+            return split[0];
+        }
+        return "";
+    }
+
+    public static String getEventData( DropEvent event ) {
+        final String data = event.getData( FORMAT );
+        final String[] split = data.split( SEPARATOR );
+        if ( split.length > 1 ) {
+            return split[1];
+        }
+        return "";
+    }
+}

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DragGridElement.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DragGridElement.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.DragStartHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.InputGroup;
@@ -46,11 +47,8 @@ public class DragGridElement extends Composite {
 
     void createDragStart( DragStartEvent event,
                           LayoutDragComponent type ) {
-        if ( type instanceof InternalDragComponent ) {
-            event.setData(InternalDragComponent.INTERNAL_DRAG_COMPONENT, ((GridLayoutDragComponent) type).label());
-        } else {
-            event.setData( LayoutDragComponent.class.toString(), type.getClass().getName() );
-        }
+
+        event.setData( DndData.FORMAT,  DndData.generateData( type ) );
 
         event.getDataTransfer().setDragImage( move.getElement(), 10, 10 );
     }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DropColumnPanel.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DropColumnPanel.java
@@ -10,6 +10,7 @@ import com.google.gwt.event.dom.client.DropHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.FlowPanel;
 import org.gwtbootstrap3.client.ui.Label;
+import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
 import org.uberfire.ext.layout.editor.client.components.LayoutComponentView;
 import org.uberfire.ext.layout.editor.client.resources.WebAppResource;
 import org.uberfire.ext.layout.editor.client.row.RowView;
@@ -54,21 +55,20 @@ public class DropColumnPanel extends FlowPanel {
     void dropHandler( DropEvent event ) {
         event.preventDefault();
 
-        if ( isInternalDragComponent( event ) ) {
-            handleGridDrop( event );
+        if ( isInternalDragComponent( DndData.getEventType( event ) ) ) {
+            handleGridDrop( DndData.getEventData( event ) );
         } else {
-            handleExternalLayoutDragComponent( event );
+            handleExternalLayoutDragComponent( DndData.getEventData( event ) );
         }
+
         dragLeaveHandler();
     }
 
-    private boolean isInternalDragComponent( DropEvent event ) {
-        String dragTypeClassName = event.getData( InternalDragComponent.INTERNAL_DRAG_COMPONENT );
-        return dragTypeClassName != null && !dragTypeClassName.isEmpty();
+    private boolean isInternalDragComponent( String eventType ) {
+        return !eventType.isEmpty() && eventType.equalsIgnoreCase( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT );
     }
 
-    private void handleExternalLayoutDragComponent( DropEvent event ) {
-        String dragTypeClassName = event.getData( LayoutDragComponent.class.toString() );
+    private void handleExternalLayoutDragComponent( String dragTypeClassName ) {
         LayoutDragComponent layoutDragComponent = getLayoutDragComponent( dragTypeClassName );
         if ( layoutDragComponent != null ) {
             handleLayoutDrop( layoutDragComponent );
@@ -102,8 +102,7 @@ public class DropColumnPanel extends FlowPanel {
         parent.getWidget().add( new LayoutComponentView( parent, layoutDragComponent, true ) );
     }
 
-    private void handleGridDrop( DropEvent event ) {
-        String grid = event.getData( InternalDragComponent.INTERNAL_DRAG_COMPONENT );
+    private void handleGridDrop( String grid ) {
         parent.getWidget().remove( this );
         parent.getWidget().add( new RowView( parent, grid, this ) );
     }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DropRowPanel.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DropRowPanel.java
@@ -10,6 +10,7 @@ import com.google.gwt.event.dom.client.DropHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.FlowPanel;
 import org.gwtbootstrap3.client.ui.Label;
+import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
 import org.uberfire.ext.layout.editor.client.resources.WebAppResource;
 import org.uberfire.ext.layout.editor.client.row.RowView;
 import org.uberfire.ext.layout.editor.client.structure.LayoutEditorWidget;
@@ -49,15 +50,14 @@ public class DropRowPanel extends FlowPanel {
 
     void dropHandler( DropEvent event ) {
         event.preventDefault();
-        if ( isInternalDragComponent( event ) ) {
-            handleGridDrop( event );
+        if ( isInternalDragComponent( DndData.getEventType( event ) ) ) {
+            handleGridDrop( DndData.getEventData( event ) );
         }
         dragLeaveHandler();
     }
 
-    private boolean isInternalDragComponent( DropEvent event ) {
-        String dragTypeClassName = event.getData( InternalDragComponent.INTERNAL_DRAG_COMPONENT );
-        return dragTypeClassName != null;
+    private boolean isInternalDragComponent( String eventType ) {
+        return !eventType.isEmpty() && eventType.equalsIgnoreCase( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT );
     }
 
     void dragOverHandler() {
@@ -78,8 +78,7 @@ public class DropRowPanel extends FlowPanel {
         getElement().removeClassName( className );
     }
 
-    private void handleGridDrop( DropEvent event ) {
-        String grid = event.getData( InternalDragComponent.INTERNAL_DRAG_COMPONENT );
+    private void handleGridDrop( String grid ) {
         if ( isAGridDrop( grid ) ) {
             parent.getWidget().remove( this );
             parent.getWidget().add( createRowView( grid ) );

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DndDataTest.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DndDataTest.java
@@ -1,0 +1,95 @@
+/*
+* Copyright 2015 JBoss Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.uberfire.ext.layout.editor.client.dnd;
+
+import com.google.gwt.event.dom.client.DropEvent;
+import com.google.gwt.user.client.ui.IsWidget;
+import org.junit.Before;
+import org.junit.Test;
+import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.components.RenderingContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.uberfire.ext.layout.editor.client.dnd.DndData.prepareData;
+
+public class DndDataTest {
+
+    GridLayoutDragComponent internal;
+    LayoutDragComponent external;
+    DropEvent internalEvent;
+    DropEvent externalEvent;
+
+    private final String INTERNAL_TYPE = "INTERNAL_DRAG_COMPONENT";
+    private final String INTERNAL_VALUE = "label";
+    private final String INTERNAL_DATA = prepareData( INTERNAL_TYPE, INTERNAL_VALUE );
+
+    private final String EXTERNAL_TYPE = "interface org.uberfire.ext.layout.editor.client.components.LayoutDragComponent";
+    private final String EXTERNAL_VALUE = "org.uberfire.ext.layout.editor.client.dnd.DndDataTest$DummyLayoutDragComponent";
+    private final String EXTERNAL_DATA = prepareData( EXTERNAL_TYPE, EXTERNAL_VALUE );
+
+
+    @Before
+    public void setup() {
+        internal = mock( GridLayoutDragComponent.class );
+        when( internal.label() ).thenReturn( "label" );
+        external = new DummyLayoutDragComponent();
+
+        internalEvent = mock( DropEvent.class );
+        when( internalEvent.getData( DndData.FORMAT ) ).thenReturn( INTERNAL_DATA );
+
+        externalEvent = mock( DropEvent.class );
+        when( externalEvent.getData( DndData.FORMAT ) ).thenReturn( EXTERNAL_DATA );
+    }
+
+    @Test
+    public void testGenerate() throws Exception {
+        assertEquals( INTERNAL_DATA, DndData.generateData( internal ) );
+        assertEquals( EXTERNAL_DATA, DndData.generateData( external ) );
+    }
+
+    @Test
+    public void testGetEventType() throws Exception {
+
+        assertEquals( INTERNAL_TYPE, DndData.getEventType( internalEvent ) );
+        assertEquals( INTERNAL_VALUE, DndData.getEventData( internalEvent ) );
+
+        assertEquals( EXTERNAL_TYPE, DndData.getEventType( externalEvent ) );
+        assertEquals( EXTERNAL_VALUE, DndData.getEventData( externalEvent ) );
+
+    }
+
+    private class DummyLayoutDragComponent implements LayoutDragComponent {
+
+        @Override
+        public IsWidget getDragWidget() {
+            return null;
+        }
+
+        @Override
+        public IsWidget getPreviewWidget( RenderingContext ctx ) {
+            return null;
+        }
+
+        @Override
+        public IsWidget getShowWidget( RenderingContext ctx ) {
+            return null;
+        }
+    }
+
+}

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DragGridElementTest.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DragGridElementTest.java
@@ -7,10 +7,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
-import org.uberfire.ext.layout.editor.client.components.InternalDragComponent;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
 
 import static org.mockito.Mockito.*;
+import static org.uberfire.ext.layout.editor.client.dnd.DndData.prepareData;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class DragGridElementTest {
@@ -35,17 +35,24 @@ public class DragGridElementTest {
 
         externalGridElement.createDragStart( dragStartEvent, externalType );
 
-        verify( dragStartEvent ).setData( LayoutDragComponent.class.toString(), externalType.getClass().getName() );
+        String data = prepareData( LayoutDragComponent.class.toString(), externalType.getClass().getName() );
+        verify( dragStartEvent ).setData( DndData.FORMAT, data );
     }
 
     @Test
     public void createDragStartInternalComponent() throws Exception {
+        String data = prepareData( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT, "label" );
         DragStartEvent dragStartEvent = mock( DragStartEvent.class );
-        when( dragStartEvent.getDataTransfer() ).thenReturn( mock( DataTransfer.class ) );
+        when( internalType.label() ).thenReturn( "label" );
+
+        final DataTransfer mock = mock( DataTransfer.class );
+        when( mock.getData( DndData.FORMAT ) ).thenReturn( data );
+
+        when( dragStartEvent.getDataTransfer() ).thenReturn( mock );
 
         internalGridElement.createDragStart( dragStartEvent, internalType );
 
-        verify( dragStartEvent ).setData( InternalDragComponent.INTERNAL_DRAG_COMPONENT, internalType.label() );
+        verify( dragStartEvent ).setData( DndData.FORMAT, data );
     }
 
 }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DropColumnPanelTest.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DropColumnPanelTest.java
@@ -94,7 +94,8 @@ public class DropColumnPanelTest {
     @Test
     public void dropHandlerOfAGridTest() {
         DropEvent event = mock( DropEvent.class );
-        when( event.getData( InternalDragComponent.INTERNAL_DRAG_COMPONENT ) ).thenReturn( "12" );
+        String data = DndData.prepareData( InternalDragComponent.INTERNAL_DRAG_COMPONENT, "12" );
+        when( event.getData( DndData.FORMAT ) ).thenReturn( data );
         dropColumnPanel.dropHandler( event );
         verify( columnContainer ).remove( dropColumnPanel );
         //dropped view
@@ -104,7 +105,8 @@ public class DropColumnPanelTest {
     @Test
     public void handleExternalLayoutDropComponent() {
         DropEvent event = mock( DropEvent.class );
-        when( event.getData( LayoutDragComponent.class.toString() ) ).thenReturn( "dragClass" );
+        String data = DndData.prepareData( LayoutDragComponent.class.toString(), "dragClass" );
+        when( event.getData( DndData.FORMAT ) ).thenReturn( data );
 
         dropColumnPanel.dropHandler( event );
         verify( columnContainer ).remove( dropColumnPanel );
@@ -114,10 +116,13 @@ public class DropColumnPanelTest {
         verify( componentConfigureModal, never() ).show();
     }
 
+
+
     @Test
     public void handleExternalLayoutDropComponentWithConfigureModal() {
         DropEvent event = mock( DropEvent.class );
-        when( event.getData( LayoutDragComponent.class.toString() ) ).thenReturn( ModalDragComponent.class.getName() );
+        String data = DndData.prepareData( LayoutDragComponent.class.toString(), ModalDragComponent.class.getName() );
+        when( event.getData( DndData.FORMAT ) ).thenReturn( data );
 
         dropColumnPanel.dropHandler( event );
         verify( columnContainer ).remove( dropColumnPanel );

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DropRowPanelTest.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DropRowPanelTest.java
@@ -33,7 +33,8 @@ public class DropRowPanelTest {
     @Test
     public void dropHandlerOfAGridTest() {
         DropEvent event = mock( DropEvent.class );
-        when( event.getData( InternalDragComponent.INTERNAL_DRAG_COMPONENT ) ).thenReturn( "12" );
+        String data = DndData.prepareData( InternalDragComponent.INTERNAL_DRAG_COMPONENT, "12" );
+        when( event.getData( DndData.FORMAT ) ).thenReturn( data );
         dropRowPanel.dropHandler( event );
         verify( dropPanel ).remove( dropRowPanel );
         //dropped view
@@ -45,7 +46,9 @@ public class DropRowPanelTest {
     @Test
     public void dropHandlerOfWrongComponentTest() {
         DropEvent event = mock( DropEvent.class );
-        when( event.getData( InternalDragComponent.INTERNAL_DRAG_COMPONENT ) ).thenReturn( "" );
+        String data = DndData.prepareData( InternalDragComponent.INTERNAL_DRAG_COMPONENT, "" );
+
+        when( event.getData( DndData.FORMAT ) ).thenReturn( data );
         dropRowPanel.dropHandler( event );
         //nothing happens
         verify( dropPanel, never() ).remove( dropRowPanel );


### PR DESCRIPTION
We used to use the format parameter of HTML 5 native DND  event.setData( format, data) to specify which type of component are on drag and drop.

     event.setData( LayoutDragComponent.class.toString(), type.getClass().getName() );

However, this doesn't work on ie11 because it requires that the format parameter is exactly the String "text".

    public static final String FORMAT = "text";
     ...
    event.setData( DndData.FORMAT,  DndData.generateData( type ) ) 
