### PR TITLE
BZ1269366: Indexing DRL related files logs null error instead of real cause

### DIFF
--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/BatchIndex.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/BatchIndex.java
@@ -167,13 +167,15 @@ public final class BatchIndex {
 
                                           //Additional indexing
                                           for ( Indexer indexer : IndexersFactory.getIndexers() ) {
-                                              if ( indexer.supportsPath( file ) ) {
-                                                  final KObject kObject = indexer.toKObject( file );
-                                                  if ( kObject != null ) {
-                                                      if ( !indexDisposed.get() ) {
-                                                          indexEngine.index( kObject );
-                                                      } else {
-                                                          return FileVisitResult.TERMINATE;
+                                              if ( file.getFileSystem().isOpen() ) {
+                                                  if ( indexer.supportsPath( file ) ) {
+                                                      final KObject kObject = indexer.toKObject( file );
+                                                      if ( kObject != null ) {
+                                                          if ( !indexDisposed.get() ) {
+                                                              indexEngine.index( kObject );
+                                                          } else {
+                                                              return FileVisitResult.TERMINATE;
+                                                          }
                                                       }
                                                   }
                                               }

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
@@ -261,6 +261,9 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
                         @Override
                         public void run() {
                             for ( WatchEvent object : events ) {
+                                if ( isDisposed() ) {
+                                    return;
+                                }
                                 try {
                                     final WatchContext context = ( (WatchContext) object.context() );
                                     if ( object.kind() == ENTRY_MODIFY || object.kind() == ENTRY_CREATE ) {
@@ -279,6 +282,9 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
 
                                             //Additional indexing
                                             for ( Indexer indexer : IndexersFactory.getIndexers() ) {
+                                                if ( isDisposed() ) {
+                                                    return;
+                                                }
                                                 if ( indexer.supportsPath( path ) ) {
                                                     final KObject kObject = indexer.toKObject( path );
                                                     if ( kObject != null ) {
@@ -297,6 +303,9 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
 
                                         //Additional indexing
                                         for ( Indexer indexer : IndexersFactory.getIndexers() ) {
+                                            if ( isDisposed() ) {
+                                                return;
+                                            }
                                             if ( indexer.supportsPath( destinationPath ) ) {
                                                 final KObjectKey kObjectSource = indexer.toKObjectKey( sourcePath );
                                                 final KObject kObjectDestination = indexer.toKObject( destinationPath );
@@ -315,6 +324,9 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
 
                                         //Additional indexing
                                         for ( Indexer indexer : IndexersFactory.getIndexers() ) {
+                                            if ( isDisposed() ) {
+                                                return;
+                                            }
                                             if ( indexer.supportsPath( oldPath ) ) {
                                                 final KObjectKey kObject = indexer.toKObjectKey( oldPath );
                                                 if ( kObject != null ) {
@@ -329,6 +341,11 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
                                 }
                             }
                         }
+
+                        private boolean isDisposed() {
+                            return isDisposed || ws.isClose();
+                        }
+
                     };
                     if ( defaultInstance.equals( unmanagedInstance ) ) {
                         // if default and unmanaged are same instance simply run the job to avoid duplicated threads

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IndexersFactory.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IndexersFactory.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.uberfire.ext.metadata.engine.Indexer;
 import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.ext.metadata.engine.Indexer;
 
 /**
  * Container for Indexers setup by CDI after IOServiceIndexedImpl has been created
@@ -36,6 +36,10 @@ public class IndexersFactory {
 
     public static List<Indexer> getIndexers() {
         return Collections.unmodifiableList( indexers );
+    }
+
+    public static void clear() {
+        indexers.clear();
     }
 
 }


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1269366

The changes in this PR came about from tests in ```kie-wb-common``` and ```drools-wb``` where it was noticed:-
1) The registered ```Indexers``` in ```IndexersFactory``` grew as subsequent unit tests ran.
2) Closing ```IOService``` (to terminate ```WatchServices```) could lead to a race condition in the asynchronous ```Indexer``` implementations. 