### PR TITLE
BZ1269333: Result of searching assets by Business Central includes duplicate records

### DIFF
--- a/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/model/KObject.java
+++ b/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/model/KObject.java
@@ -19,5 +19,7 @@ package org.uberfire.ext.metadata.model;
 public interface KObject extends KObjectKey,
                                  PropertyBag {
 
+    boolean isFullText();
+
 }
 

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexEngine.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexEngine.java
@@ -117,6 +117,9 @@ public class LuceneIndexEngine implements MetaIndexEngine {
         doc.add( new StringField( "segment.id",
                                   object.getSegmentId(),
                                   Field.Store.YES ) );
+        doc.add( new StringField( "full",
+                                  Boolean.toString( object.isFullText() ),
+                                  Field.Store.YES ) );
 
         final StringBuilder allText = new StringBuilder( object.getKey() ).append( '\n' );
 
@@ -124,15 +127,19 @@ public class LuceneIndexEngine implements MetaIndexEngine {
             final IndexableField[] fields = fieldFactory.build( property );
             for ( final IndexableField field : fields ) {
                 doc.add( field );
-                if ( field instanceof TextField && !( property.getValue() instanceof Boolean ) ) {
-                    allText.append( field.stringValue() ).append( '\n' );
+                if ( object.isFullText() ) {
+                    if ( field instanceof TextField && !( property.getValue() instanceof Boolean ) ) {
+                        allText.append( field.stringValue() ).append( '\n' );
+                    }
                 }
             }
         }
 
-        doc.add( new TextField( FULL_TEXT_FIELD,
-                                allText.toString().toLowerCase(),
-                                Field.Store.NO ) );
+        if ( object.isFullText() ) {
+            doc.add( new TextField( FULL_TEXT_FIELD,
+                                    allText.toString().toLowerCase(),
+                                    Field.Store.NO ) );
+        }
 
         return doc;
     }

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/util/KObjectUtil.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/util/KObjectUtil.java
@@ -64,6 +64,11 @@ public final class KObjectUtil {
             }
 
             @Override
+            public boolean isFullText() {
+                return Boolean.parseBoolean( document.get( "full" ) );
+            }
+
+            @Override
             public boolean equals( final Object obj ) {
                 if ( obj == null ) {
                     return false;

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/KObjectUtil.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/KObjectUtil.java
@@ -120,6 +120,11 @@ public final class KObjectUtil {
             }
 
             @Override
+            public boolean isFullText() {
+                return true;
+            }
+
+            @Override
             public Iterable<KProperty<?>> getProperties() {
                 return new ArrayList<KProperty<?>>( attrs.length ) {{
                     for ( final FileAttribute<?> attr : attrs ) {

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/BatchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/BatchIndexTest.java
@@ -248,6 +248,16 @@ public class BatchIndexTest {
                         assertEquals( 1, hits.length );
                     }
 
+                    {
+                        final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+
+                        searcher.search( new TermQuery( new Term( "fullText", "second" ) ), collector );
+
+                        final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+
+                        assertEquals( 1, hits.length );
+                    }
+
                     ( (LuceneIndex) index ).nrtRelease( searcher );
 
                 } catch ( Exception ex ) {


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1269333

The issue was caused by ```LuceneIndexEngine``` writing "full text" index entries for all indexers; the default and additional ```Indexer``` implementations in ```kie-wb-common```. We now restrict creation of the "full text" index entries to the default indexing.