### PR TITLE
Removed side margins from table components

### DIFF
--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.ui.xml
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.ui.xml
@@ -23,7 +23,8 @@
 
   <ui:style>
     .dataGridContainer {
-      margin: 10px;
+      padding-top: 10px;
+      padding-bottom: 10px;
     }
 
     .leftToolBar {

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/SimpleTable.ui.xml
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/SimpleTable.ui.xml
@@ -22,7 +22,8 @@
 
   <ui:style>
     .dataGridContainer {
-      margin: 10px;
+      padding-top: 10px;
+      padding-bottom: 10px;
     }
 
     .horizontalContainer {


### PR DESCRIPTION
Most use cases only need top and bottom margins. Side margins often cause extra css to override and remove it.