### PR TITLE
wires-webapp: remove GWT permutations for IE10 and older

### DIFF
--- a/uberfire-wires/uberfire-wires-webapp/src/main/resources/org/uberfire/ext/wires/WiresShowcase.gwt.xml
+++ b/uberfire-wires/uberfire-wires-webapp/src/main/resources/org/uberfire/ext/wires/WiresShowcase.gwt.xml
@@ -33,4 +33,7 @@
   <source path='client'/>
   <source path='shared'/>
 
+  <!-- We don't need to support IE10 or older -->
+  <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
+  <set-property name="user.agent" value="gecko1_8,safari"/>
 </module>


### PR DESCRIPTION
Same changes were already merged to master.