### PR TITLE
BZ1269333: Result of searching Assets in Business Central's 'Full Text Search' includes duplicate records

### DIFF
--- a/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/engine/MetaIndexEngine.java
+++ b/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/engine/MetaIndexEngine.java
@@ -23,7 +23,7 @@ import org.uberfire.ext.metadata.model.KObjectKey;
 
 public interface MetaIndexEngine extends PriorityDisposable {
 
-    public static final String FULL_TEXT_FIELD = "fullText";
+    String FULL_TEXT_FIELD = "fullText";
 
     boolean freshIndex( final KCluster cluster );
 

--- a/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/model/KObject.java
+++ b/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/model/KObject.java
@@ -19,5 +19,15 @@ package org.uberfire.ext.metadata.model;
 public interface KObject extends KObjectKey,
                                  PropertyBag {
 
+    /**
+     * Flag indicating whether a "full text" entry should be created for the KObject.
+     * This should be true for "default indexing", i.e. that supported out of the box; however
+     * additional indexers should not create additional "full text" entries.
+     * @return
+     * @see org.uberfire.ext.metadata.engine.MetaIndexEngine#FULL_TEXT_FIELD
+     * @see org.uberfire.ext.metadata.engine.Indexer
+     */
+    boolean fullText();
+
 }
 

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexEngine.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexEngine.java
@@ -130,9 +130,12 @@ public class LuceneIndexEngine implements MetaIndexEngine {
             }
         }
 
-        doc.add( new TextField( FULL_TEXT_FIELD,
-                                allText.toString().toLowerCase(),
-                                Field.Store.NO ) );
+        //Only create a "full text" entry if required
+        if ( object.fullText() ) {
+            doc.add( new TextField( FULL_TEXT_FIELD,
+                                    allText.toString().toLowerCase(),
+                                    Field.Store.NO ) );
+        }
 
         return doc;
     }

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/util/KObjectUtil.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/util/KObjectUtil.java
@@ -115,6 +115,11 @@ public final class KObjectUtil {
                 return kProperties;
             }
 
+            @Override
+            public boolean fullText() {
+                return true;
+            }
+
             private boolean isExtension( final String name ) {
                 return !( name.equals( "id" ) || name.equals( "type" ) || name.equals( "cluster.id" ) || name.equals( "segment.id" ) || name.equals( "key" ) );
             }

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/KObjectUtil.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/KObjectUtil.java
@@ -20,17 +20,17 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 
-import org.uberfire.java.nio.base.FileSystemId;
-import org.uberfire.java.nio.base.SegmentedPath;
-import org.uberfire.java.nio.file.FileSystem;
-import org.uberfire.java.nio.file.Path;
-import org.uberfire.java.nio.file.attribute.FileAttribute;
 import org.uberfire.ext.metadata.backend.lucene.model.KClusterImpl;
 import org.uberfire.ext.metadata.model.KCluster;
 import org.uberfire.ext.metadata.model.KObject;
 import org.uberfire.ext.metadata.model.KObjectKey;
 import org.uberfire.ext.metadata.model.KProperty;
 import org.uberfire.ext.metadata.model.schema.MetaType;
+import org.uberfire.java.nio.base.FileSystemId;
+import org.uberfire.java.nio.base.SegmentedPath;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.attribute.FileAttribute;
 
 import static org.apache.commons.codec.binary.Base64.*;
 import static org.apache.commons.io.FilenameUtils.*;
@@ -199,6 +199,11 @@ public final class KObjectUtil {
                     } );
 
                 }};
+            }
+
+            @Override
+            public boolean fullText() {
+                return true;
             }
 
             @Override

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/BaseIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/BaseIndexTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.metadata.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
+import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.io.IOService;
+import org.uberfire.io.attribute.DublinCoreView;
+import org.uberfire.java.nio.base.version.VersionAttributeView;
+import org.uberfire.java.nio.file.Path;
+
+import static org.uberfire.ext.metadata.backend.lucene.util.KObjectUtil.*;
+
+public abstract class BaseIndexTest {
+
+    private int seed = new Random( 10L ).nextInt();
+
+    protected boolean created = false;
+    protected Map<String, Path> basePaths = new HashMap<String, Path>();
+
+    protected LuceneConfig config;
+    protected IOService ioService = null;
+
+    protected static final List<File> tempFiles = new ArrayList<File>();
+
+    @AfterClass
+    @BeforeClass
+    public static void cleanup() {
+        for ( final File tempFile : tempFiles ) {
+            FileUtils.deleteQuietly( tempFile );
+        }
+    }
+
+    protected IOService ioService() {
+        if ( ioService == null ) {
+            config = new LuceneConfigBuilder()
+                    .withInMemoryMetaModelStore()
+                    .useDirectoryBasedIndex()
+                    .useInMemoryDirectory()
+                    .build();
+
+            ioService = new IOServiceIndexedImpl( config.getIndexEngine(),
+                                                  DublinCoreView.class,
+                                                  VersionAttributeView.class );
+        }
+        return ioService;
+    }
+
+    protected static File createTempDirectory() throws IOException {
+        final File temp = File.createTempFile( "temp", Long.toString( System.nanoTime() ) );
+        if ( !( temp.delete() ) ) {
+            throw new IOException( "Could not delete temp file: " + temp.getAbsolutePath() );
+        }
+        if ( !( temp.mkdir() ) ) {
+            throw new IOException( "Could not create temp directory: " + temp.getAbsolutePath() );
+        }
+        tempFiles.add( temp );
+        return temp;
+    }
+
+    @Before
+    public void setup() throws IOException {
+        IndexersFactory.clear();
+        if ( !created ) {
+            final String path = createTempDirectory().getAbsolutePath();
+            System.setProperty( "org.uberfire.nio.git.dir",
+                                path );
+            System.out.println( ".niogit: " + path );
+
+            for ( String repositoryName : getRepositoryNames() ) {
+
+                final URI newRepo = URI.create( "git://" + repositoryName );
+
+                try {
+                    ioService().newFileSystem( newRepo,
+                                               new HashMap<String, Object>() );
+
+                    final Path basePath = getDirectoryPath( repositoryName ).resolveSibling( "root" );
+                    basePaths.put( repositoryName,
+                                   basePath );
+
+                } catch ( final Exception ex ) {
+                    ex.fillInStackTrace();
+                    System.out.println( ex.getMessage() );
+                } finally {
+                    created = true;
+                }
+            }
+        }
+    }
+
+    protected abstract String[] getRepositoryNames();
+
+    protected Path getBasePath( final String repositoryName ) {
+        return basePaths.get( repositoryName );
+    }
+
+    protected void listHitPaths( final IndexSearcher searcher,
+                                 final ScoreDoc[] hits ) throws IOException {
+        for ( int i = 0; i < hits.length; i++ ) {
+            final KObject ko = toKObject( searcher.doc( hits[ i ].doc ) );
+            System.out.println( ko.getKey() );
+        }
+    }
+
+    private Path getDirectoryPath( final String repositoryName ) {
+        final Path dir = ioService().get( URI.create( "git://" + repositoryName + "/_someDir" + seed ) );
+        ioService().deleteIfExists( dir );
+        return dir;
+    }
+
+}

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/BatchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/BatchIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss, by Red Hat, Inc
+ * Copyright 2015 JBoss, by Red Hat, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,9 @@
 
 package org.uberfire.ext.metadata.io;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
@@ -29,9 +26,7 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopScoreDocCollector;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
 import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
 import org.uberfire.ext.metadata.engine.Index;
@@ -46,21 +41,7 @@ import org.uberfire.java.nio.file.attribute.FileAttribute;
 import static org.junit.Assert.*;
 import static org.uberfire.ext.metadata.io.KObjectUtil.*;
 
-/**
- *
- */
-public class BatchIndexTest {
-
-    private static IOService ioService = null;
-    private static LuceneConfig config;
-
-    public static IOService ioService() throws InterruptedException {
-        if ( ioService == null ) {
-            config = new LuceneConfigBuilder().withInMemoryMetaModelStore().useDirectoryBasedIndex().useInMemoryDirectory().build();
-            ioService = new IOServiceDotFileImpl();
-        }
-        return ioService;
-    }
+public class BatchIndexTest extends BaseIndexTest {
 
     public static Observer observer() {
         return new Observer() {
@@ -81,25 +62,31 @@ public class BatchIndexTest {
         };
     }
 
-    @BeforeClass
-    public static void setup() throws IOException {
-        final String path = createTempDirectory().getAbsolutePath();
-        System.setProperty( "org.uberfire.nio.git.dir", path );
-        System.out.println( ".niogit: " + path );
-
-        final URI newRepo = URI.create( "git://temp-repo-test" );
-
-        try {
-            ioService().newFileSystem( newRepo, new HashMap<String, Object>() );
-        } catch ( final Exception ex ) {
+    @Override
+    protected IOService ioService() {
+        if ( ioService == null ) {
+            config = new LuceneConfigBuilder()
+                    .withInMemoryMetaModelStore()
+                    .useDirectoryBasedIndex()
+                    .useInMemoryDirectory()
+                    .build();
+            ioService = new IOServiceDotFileImpl();
         }
+        return ioService;
+    }
+
+    @Override
+    protected String[] getRepositoryNames() {
+        return new String[]{ "temp-repo-test" };
     }
 
     @Test
     public void testIndex() throws IOException, InterruptedException {
         {
             final Path file = ioService().get( "git://temp-repo-test/path/to/file.txt" );
-            ioService().write( file, "some content here", Collections.<OpenOption>emptySet(), new FileAttribute<Object>() {
+            ioService().write( file,
+                               "some content here", Collections.<OpenOption>emptySet(),
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.author";
@@ -109,7 +96,8 @@ public class BatchIndexTest {
                                    public Object value() {
                                        return "My User Name Here";
                                    }
-                               }, new FileAttribute<Object>() {
+                               },
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.lastModification";
@@ -119,7 +107,8 @@ public class BatchIndexTest {
                                    public Object value() {
                                        return new Date();
                                    }
-                               }, new FileAttribute<Object>() {
+                               },
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.comment";
@@ -134,7 +123,10 @@ public class BatchIndexTest {
         }
         {
             final Path file = ioService().get( "git://temp-repo-test/path/to/some/complex/file.txt" );
-            ioService().write( file, "some other content here", Collections.<OpenOption>emptySet(), new FileAttribute<Object>() {
+            ioService().write( file,
+                               "some other content here",
+                               Collections.<OpenOption>emptySet(),
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.author";
@@ -144,7 +136,8 @@ public class BatchIndexTest {
                                    public Object value() {
                                        return "My Second User Name";
                                    }
-                               }, new FileAttribute<Object>() {
+                               },
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.lastModification";
@@ -154,7 +147,8 @@ public class BatchIndexTest {
                                    public Object value() {
                                        return new Date();
                                    }
-                               }, new FileAttribute<Object>() {
+                               },
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.comment";
@@ -169,7 +163,10 @@ public class BatchIndexTest {
         }
         {
             final Path file = ioService().get( "git://temp-repo-test/simple.doc" );
-            ioService().write( file, "some doc content here", Collections.<OpenOption>emptySet(), new FileAttribute<Object>() {
+            ioService().write( file,
+                               "some doc content here",
+                               Collections.<OpenOption>emptySet(),
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.author";
@@ -179,7 +176,8 @@ public class BatchIndexTest {
                                    public Object value() {
                                        return "My Original User";
                                    }
-                               }, new FileAttribute<Object>() {
+                               },
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.lastModification";
@@ -189,7 +187,8 @@ public class BatchIndexTest {
                                    public Object value() {
                                        return new Date();
                                    }
-                               }, new FileAttribute<Object>() {
+                               },
+                               new FileAttribute<Object>() {
                                    @Override
                                    public String name() {
                                        return "dcore.comment";
@@ -205,72 +204,61 @@ public class BatchIndexTest {
 
         {
             final Path file = ioService().get( "git://temp-repo-test/xxx/simple.xls" );
-            ioService().write( file, "plans!?" );
+            ioService().write( file,
+                               "plans!?" );
         }
 
         new BatchIndex( config.getIndexEngine(),
                         ioService(),
                         observer(),
-                        DublinCoreView.class ).run( ioService().get( "git://temp-repo-test/" ), new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    final Index index = config.getIndexManager().get( toKCluster( ioService().get( "git://temp-repo-test/" ).getFileSystem() ) );
+                        DublinCoreView.class ).run( ioService().get( "git://temp-repo-test/" ),
+                                                    new Runnable() {
 
-                    final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
-                    {
-                        final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+                                                        @Override
+                                                        public void run() {
+                                                            try {
+                                                                final Index index = config.getIndexManager().get( toKCluster( ioService().get( "git://temp-repo-test/" ).getFileSystem() ) );
 
-                        searcher.search( new MatchAllDocsQuery(), collector );
+                                                                final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
+                                                                {
+                                                                    final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
 
-                        final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+                                                                    searcher.search( new MatchAllDocsQuery(), collector );
 
-                        assertEquals( 4, hits.length );
-                    }
+                                                                    final ScoreDoc[] hits = collector.topDocs().scoreDocs;
 
-                    {
-                        final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+                                                                    assertEquals( 4, hits.length );
+                                                                }
 
-                        searcher.search( new TermQuery( new Term( "dcore.author", "name" ) ), collector );
+                                                                {
+                                                                    final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
 
-                        final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+                                                                    searcher.search( new TermQuery( new Term( "dcore.author", "name" ) ), collector );
 
-                        assertEquals( 2, hits.length );
-                    }
+                                                                    final ScoreDoc[] hits = collector.topDocs().scoreDocs;
 
-                    {
-                        final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+                                                                    assertEquals( 2, hits.length );
+                                                                }
 
-                        searcher.search( new TermQuery( new Term( "dcore.author", "second" ) ), collector );
+                                                                {
+                                                                    final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
 
-                        final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+                                                                    searcher.search( new TermQuery( new Term( "dcore.author", "second" ) ), collector );
 
-                        assertEquals( 1, hits.length );
-                    }
+                                                                    final ScoreDoc[] hits = collector.topDocs().scoreDocs;
 
-                    ( (LuceneIndex) index ).nrtRelease( searcher );
+                                                                    assertEquals( 1, hits.length );
+                                                                }
 
-                } catch ( Exception ex ) {
-                    ex.printStackTrace();
-                    fail();
-                }
-            }
-        } );
+                                                                ( (LuceneIndex) index ).nrtRelease( searcher );
 
-    }
+                                                            } catch ( Exception ex ) {
+                                                                ex.printStackTrace();
+                                                                fail();
+                                                            }
+                                                        }
+                                                    } );
 
-    public static File createTempDirectory()
-            throws IOException {
-        final File temp = File.createTempFile( "temp", Long.toString( System.nanoTime() ) );
-        if ( !( temp.delete() ) ) {
-            throw new IOException( "Could not delete temp file: " + temp.getAbsolutePath() );
-        }
-
-        if ( !( temp.mkdir() ) ) {
-            throw new IOException( "Could not create temp directory: " + temp.getAbsolutePath() );
-        }
-
-        return temp;
     }
 
 }

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/IOServiceIndexedGitImplTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/IOServiceIndexedGitImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss, by Red Hat, Inc
+ * Copyright 2015 JBoss, by Red Hat, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,35 +16,20 @@
 
 package org.uberfire.ext.metadata.io;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Random;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopScoreDocCollector;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
 import org.uberfire.ext.metadata.engine.Index;
 import org.uberfire.ext.metadata.model.KObject;
-import org.uberfire.io.IOService;
-import org.uberfire.io.attribute.DublinCoreView;
-import org.uberfire.java.nio.base.version.VersionAttributeView;
 import org.uberfire.java.nio.file.OpenOption;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.FileAttribute;
@@ -53,30 +38,22 @@ import static org.junit.Assert.*;
 import static org.uberfire.ext.metadata.backend.lucene.util.KObjectUtil.toKObject;
 import static org.uberfire.ext.metadata.io.KObjectUtil.*;
 
-/**
- *
- */
-public class IOServiceIndexedGitImplTest {
+public class IOServiceIndexedGitImplTest extends BaseIndexTest {
 
-    protected IOService ioService = null;
-    private static LuceneConfig config;
+    protected final Date dateValue = new Date();
 
-    public IOService ioService() {
-        if ( ioService == null ) {
-            config = new LuceneConfigBuilder().withInMemoryMetaModelStore().useDirectoryBasedIndex().useInMemoryDirectory().build();
-            ioService = new IOServiceIndexedImpl( config.getIndexEngine(),
-                                                  DublinCoreView.class,
-                                                  VersionAttributeView.class );
-        }
-        return ioService;
+    @Override
+    protected String[] getRepositoryNames() {
+        return new String[]{ this.getClass().getSimpleName() };
     }
 
     @Test
     public void testIndexedFile() throws IOException, InterruptedException {
-        final Path newOtherPath = getDirectoryPath().resolveSibling( "someNewOtherPath" );
-        ioService().write( newOtherPath.resolve( "dummy" ), "<none>" );
-        final Path path = newOtherPath.resolve( "myIndexedFile.txt" );
-        ioService().write( path, "ooooo!", Collections.<OpenOption>emptySet(), new FileAttribute<Object>() {
+        final Path path1 = getBasePath( this.getClass().getSimpleName() ).resolve( "myIndexedFile.txt" );
+        ioService().write( path1,
+                           "ooooo!",
+                           Collections.<OpenOption>emptySet(),
+                           new FileAttribute<Object>() {
                                @Override
                                public String name() {
                                    return "custom";
@@ -86,7 +63,8 @@ public class IOServiceIndexedGitImplTest {
                                public Object value() {
                                    return dateValue;
                                }
-                           }, new FileAttribute<String>() {
+                           },
+                           new FileAttribute<String>() {
                                @Override
                                public String name() {
                                    return "int.hello";
@@ -96,7 +74,8 @@ public class IOServiceIndexedGitImplTest {
                                public String value() {
                                    return "hello some world jhere";
                                }
-                           }, new FileAttribute<Integer>() {
+                           },
+                           new FileAttribute<Integer>() {
                                @Override
                                public String name() {
                                    return "int";
@@ -109,17 +88,21 @@ public class IOServiceIndexedGitImplTest {
                            }
                          );
 
-        ioService().write( newOtherPath.resolve( "myOtherIndexedFile.txt" ), "ooooo!", Collections.<OpenOption>emptySet(), new FileAttribute<String>() {
-            @Override
-            public String name() {
-                return "int.hello";
-            }
+        final Path path2 = getBasePath( this.getClass().getSimpleName() ).resolve( "myOtherIndexedFile.txt" );
+        ioService().write( path2,
+                           "ooooo!",
+                           Collections.<OpenOption>emptySet(),
+                           new FileAttribute<String>() {
+                               @Override
+                               public String name() {
+                                   return "int.hello";
+                               }
 
-            @Override
-            public String value() {
-                return "jhere";
-            }
-        } );
+                               @Override
+                               public String value() {
+                                   return "jhere";
+                               }
+                           } );
 
         Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
         assertNotNull( config.getMetaModelStore().getMetaObject( Path.class.getName() ) );
@@ -140,7 +123,7 @@ public class IOServiceIndexedGitImplTest {
         assertTrue( config.getMetaModelStore().getMetaObject( Path.class.getName() ).getProperty( "int.hello" ).getTypes().contains( String.class ) );
         assertTrue( config.getMetaModelStore().getMetaObject( Path.class.getName() ).getProperty( "custom" ).getTypes().contains( Date.class ) );
 
-        final Index index = config.getIndexManager().get( toKCluster( newOtherPath.getFileSystem() ) );
+        final Index index = config.getIndexManager().get( toKCluster( path2.getFileSystem() ) );
 
         final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
 
@@ -179,78 +162,11 @@ public class IOServiceIndexedGitImplTest {
             listHitPaths( searcher,
                           hits );
 
-            assertEquals( 3,
+            assertEquals( 2,
                           hits.length );
         }
 
         ( (LuceneIndex) index ).nrtRelease( searcher );
-    }
-
-    private void listHitPaths( final IndexSearcher searcher,
-                               final ScoreDoc[] hits ) throws IOException {
-        for ( int i = 0; i < hits.length; i++ ) {
-            final KObject ko = toKObject( searcher.doc( hits[ i ].doc ) );
-            System.out.println( ko.getKey() );
-        }
-    }
-
-    public Path getDirectoryPath() {
-        final Path dir = ioService().get( URI.create( "git://indexed-repo-test/_someDir" + new Random( 10L ).nextInt() ) );
-        ioService().deleteIfExists( dir );
-
-        return dir;
-    }
-
-    private Path getRootPath() {
-        return ioService().get( URI.create( "git://indexed-repo-test/" ) );
-    }
-
-    private static boolean created = false;
-
-    @Before
-    public void setup() throws IOException {
-        if ( !created ) {
-            final String path = createTempDirectory().getAbsolutePath();
-            System.setProperty( "org.uberfire.nio.git.dir", path );
-            System.out.println( ".niogit: " + path );
-
-            final URI newRepo = URI.create( "git://indexed-repo-test" );
-
-            try {
-                ioService().newFileSystem( newRepo, new HashMap<String, Object>() );
-            } catch ( final Exception ex ) {
-            } finally {
-                created = true;
-            }
-        }
-    }
-
-    protected final Date dateValue = new Date();
-
-    protected static final List<File> tempFiles = new ArrayList<File>();
-
-    @AfterClass
-    @BeforeClass
-    public static void cleanup() {
-        for ( final File tempFile : tempFiles ) {
-            FileUtils.deleteQuietly( tempFile );
-        }
-    }
-
-    public static File createTempDirectory()
-            throws IOException {
-        final File temp = File.createTempFile( "temp", Long.toString( System.nanoTime() ) );
-        if ( !( temp.delete() ) ) {
-            throw new IOException( "Could not delete temp file: " + temp.getAbsolutePath() );
-        }
-
-        if ( !( temp.mkdir() ) ) {
-            throw new IOException( "Could not create temp directory: " + temp.getAbsolutePath() );
-        }
-
-        tempFiles.add( temp );
-
-        return temp;
     }
 
 }

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneFullTextSearchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneFullTextSearchIndexTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.metadata.io;
+
+import java.io.IOException;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopScoreDocCollector;
+import org.apache.lucene.search.WildcardQuery;
+import org.junit.Test;
+import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
+import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
+import org.uberfire.ext.metadata.engine.Index;
+import org.uberfire.ext.metadata.engine.Indexer;
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.ext.metadata.model.KObjectKey;
+import org.uberfire.ext.metadata.model.KProperty;
+import org.uberfire.ext.metadata.model.schema.MetaType;
+import org.uberfire.io.IOService;
+import org.uberfire.io.attribute.DublinCoreView;
+import org.uberfire.java.nio.base.version.VersionAttributeView;
+import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.*;
+import static org.uberfire.ext.metadata.engine.MetaIndexEngine.*;
+import static org.uberfire.ext.metadata.io.KObjectUtil.*;
+
+public class LuceneFullTextSearchIndexTest extends BaseIndexTest {
+
+    @Override
+    protected IOService ioService() {
+        if ( ioService == null ) {
+            config = new LuceneConfigBuilder()
+                    .withInMemoryMetaModelStore()
+                    .useDirectoryBasedIndex()
+                    .useInMemoryDirectory()
+                    .build();
+
+            ioService = new IOServiceIndexedImpl( config.getIndexEngine(),
+                                                  DublinCoreView.class,
+                                                  VersionAttributeView.class );
+
+            IndexersFactory.addIndexer( new MockIndexer() );
+        }
+        return ioService;
+    }
+
+    private static class MockIndexer implements Indexer {
+
+        @Override
+        public boolean supportsPath( final Path path ) {
+            return true;
+        }
+
+        @Override
+        public KObject toKObject( final Path path ) {
+            return new TestKObjectWrapper( KObjectUtil.toKObject( path ) );
+        }
+
+        @Override
+        public KObjectKey toKObjectKey( final Path path ) {
+            return new TestKObjectKeyWrapper( KObjectUtil.toKObjectKey( path ) );
+        }
+
+    }
+
+    private static class TestKObjectKeyWrapper implements KObjectKey {
+
+        protected KObjectKey delegate;
+
+        private TestKObjectKeyWrapper( final KObjectKey delegate ) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String getId() {
+            return delegate.getId()+"-refactoring";
+        }
+
+        @Override
+        public MetaType getType() {
+            return delegate.getType();
+        }
+
+        @Override
+        public String getClusterId() {
+            return delegate.getClusterId();
+        }
+
+        @Override
+        public String getSegmentId() {
+            return delegate.getSegmentId();
+        }
+
+        @Override
+        public String getKey() {
+            return delegate.getKey();
+        }
+    }
+
+    private static class TestKObjectWrapper extends TestKObjectKeyWrapper implements KObject {
+
+        private TestKObjectWrapper( final KObject delegate ) {
+            super( delegate );
+        }
+
+        @Override
+        public Iterable<KProperty<?>> getProperties() {
+            return ( (KObject) delegate ).getProperties();
+        }
+
+        @Override
+        public boolean fullText() {
+            return false;
+        }
+    }
+
+    @Override
+    protected String[] getRepositoryNames() {
+        return new String[]{ this.getClass().getSimpleName() };
+    }
+
+    @Test
+    public void testFullTextIndexedFile() throws IOException, InterruptedException {
+        final Path path1 = getBasePath( this.getClass().getSimpleName() ).resolve( "mydrlfile1.drl" );
+        ioService().write( path1,
+                           "Some cheese" );
+
+        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+
+        final Index index = config.getIndexManager().get( toKCluster( path1.getFileSystem() ) );
+
+        final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
+
+        {
+            final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+
+            searcher.search( new WildcardQuery( new Term( FULL_TEXT_FIELD, "*file*" ) ), collector );
+
+            final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+            listHitPaths( searcher,
+                          hits );
+
+            assertEquals( 1,
+                          hits.length );
+        }
+
+        ( (LuceneIndex) index ).nrtRelease( searcher );
+    }
+
+}

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneSearchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneSearchIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss, by Red Hat, Inc
+ * Copyright 2015 JBoss, by Red Hat, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,120 +16,23 @@
 
 package org.uberfire.ext.metadata.io;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
-import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
 import org.uberfire.ext.metadata.search.ClusterSegment;
-import org.uberfire.io.IOService;
 import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.base.SegmentedPath;
 import org.uberfire.java.nio.file.Path;
 
 import static org.junit.Assert.*;
 
-public class LuceneSearchIndexTest {
+public class LuceneSearchIndexTest extends BaseIndexTest {
 
-    private int seed = new Random( 10L ).nextInt();
-
-    protected boolean created = false;
-    private Map<String, Path> basePaths = new HashMap<String, Path>();
-
-    private LuceneConfig config;
-    private IOService ioService = null;
-
-    protected static final List<File> tempFiles = new ArrayList<File>();
-
-    @AfterClass
-    @BeforeClass
-    public static void cleanup() {
-        for ( final File tempFile : tempFiles ) {
-            FileUtils.deleteQuietly( tempFile );
-        }
-    }
-
-    protected IOService ioService() {
-        if ( ioService == null ) {
-            config = new LuceneConfigBuilder()
-                    .withInMemoryMetaModelStore()
-                    .useDirectoryBasedIndex()
-                    .useInMemoryDirectory()
-                    .build();
-
-            ioService = new IOServiceIndexedImpl( config.getIndexEngine() );
-        }
-        return ioService;
-    }
-
-    protected static File createTempDirectory() throws IOException {
-        final File temp = File.createTempFile( "temp", Long.toString( System.nanoTime() ) );
-        if ( !( temp.delete() ) ) {
-            throw new IOException( "Could not delete temp file: " + temp.getAbsolutePath() );
-        }
-        if ( !( temp.mkdir() ) ) {
-            throw new IOException( "Could not create temp directory: " + temp.getAbsolutePath() );
-        }
-        tempFiles.add( temp );
-        return temp;
-    }
-
-    @Before
-    public void setup() throws IOException {
-        if ( !created ) {
-            final String path = createTempDirectory().getAbsolutePath();
-            System.setProperty( "org.uberfire.nio.git.dir",
-                                path );
-            System.out.println( ".niogit: " + path );
-
-            for ( String repositoryName : getRepositoryNames() ) {
-
-                final URI newRepo = URI.create( "git://" + repositoryName );
-
-                try {
-                    ioService().newFileSystem( newRepo,
-                                               new HashMap<String, Object>() );
-
-                    //Don't ask, but we need to write a single file first in order for indexing to work
-                    final Path basePath = getDirectoryPath( repositoryName ).resolveSibling( "someNewOtherPath" );
-                    ioService().write( basePath.resolve( "dummy" ),
-                                       "<none>" );
-                    basePaths.put( repositoryName,
-                                   basePath );
-
-                } catch ( final Exception ex ) {
-                    ex.fillInStackTrace();
-                    System.out.println( ex.getMessage() );
-                } finally {
-                    created = true;
-                }
-            }
-        }
-    }
-
-    private String[] getRepositoryNames() {
+    @Override
+    protected String[] getRepositoryNames() {
         return new String[]{ this.getClass().getSimpleName() + "_1", this.getClass().getSimpleName() + "_2" };
-    }
-
-    private Path getBasePath( final String repositoryName ) {
-        return basePaths.get( repositoryName );
-    }
-
-    private Path getDirectoryPath( final String repositoryName ) {
-        final Path dir = ioService().get( URI.create( "git://" + repositoryName + "/_someDir" + seed ) );
-        ioService().deleteIfExists( dir );
-        return dir;
     }
 
     @Test


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1269333

The issue is "additional indexers" also create index entries for "full text" (but with a different ID to the "default indexing"). Consequentially when performing a "full text" search two records were matched: one created by "default indexing" and the other by the "additional indexers".

Fixed and added new test. Existing tests were refactored to use a new common base class to avoid duplication of the setup/dispose etc code.