### PR TITLE
Bug 1187122 - Configurable Workbench: First letter of tag or director y name must be symbol from latin alphabet

### DIFF
--- a/uberfire-apps/uberfire-apps-client/src/main/java/org/uberfire/ext/apps/client/home/components/popup/DirectoryNameValidator.java
+++ b/uberfire-apps/uberfire-apps-client/src/main/java/org/uberfire/ext/apps/client/home/components/popup/DirectoryNameValidator.java
@@ -5,7 +5,7 @@ import org.uberfire.ext.apps.client.resources.i18n.CommonConstants;
 
 public class DirectoryNameValidator {
 
-    public static final String VALID_DIR_REGEX = "^([a-zA-Z0-9][^*\"\\/><?\\\\\\!|;:]*)$";
+    public static final String VALID_DIR_REGEX = "^([^*\"\\/><?\\\\\\!|;:]*)$";
     private final Directory currentDirectory;
 
     public DirectoryNameValidator( Directory currentDirectory ) {
@@ -17,7 +17,7 @@ public class DirectoryNameValidator {
     }
 
     public boolean isValid( String dirName ) {
-        if ( dirName == null || dirName.isEmpty() ) {
+        if ( dirName == null || dirName.trim().isEmpty() ) {
             return Boolean.FALSE;
         }
         if ( !dirName.matches( VALID_DIR_REGEX ) ) {

--- a/uberfire-apps/uberfire-apps-client/src/test/java/org/uberfire/ext/apps/client/home/components/popup/DirectoryNameValidatorTest.java
+++ b/uberfire-apps/uberfire-apps-client/src/test/java/org/uberfire/ext/apps/client/home/components/popup/DirectoryNameValidatorTest.java
@@ -22,6 +22,7 @@ public class DirectoryNameValidatorTest {
     public void isValidTest() throws Exception {
         assertTrue( directoryNameValidator.isValid( "app" ) );
         assertTrue( directoryNameValidator.isValid( "my app" ) );
+        assertTrue( directoryNameValidator.isValid( "日本国" ) );
         assertFalse( directoryNameValidator.isValid( "" ) );
         assertFalse( directoryNameValidator.isValid( " " ) );
         assertFalse( directoryNameValidator.isValid( "app\\" ) );


### PR DESCRIPTION
Fix for https://github.com/uberfire/uberfire-extensions/pull/102