### PR TITLE
Bug 1273036 - Strange behaviour of paginations in Overview Tab

### DIFF
--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
@@ -67,33 +67,21 @@ public class PagedTable<T>
 
     public PagedTable( final int pageSize ) {
         super();
-        this.pageSize=pageSize;
-        this.dataGrid.setPageSize( pageSize );
-        this.pager.setDisplay( dataGrid );
-        setShowPageSizesSelector( showPageSizesSelector );
-        createPageSizesListBox( 5, 20, 5 );
+        init( pageSize, showPageSizesSelector );
         storePageSizeInGridPreferences( pageSize );
     }
 
     public PagedTable( final int pageSize,
                        final ProvidesKey<T> providesKey ) {
         super( providesKey );
-        this.pageSize =pageSize;
-        this.dataGrid.setPageSize( pageSize );
-        this.pager.setDisplay( dataGrid );
-        setShowPageSizesSelector( showPageSizesSelector );
-        createPageSizesListBox(5,20,5);
+        init( pageSize, showPageSizesSelector );
     }
 
     public PagedTable( final int pageSize,
                        final ProvidesKey<T> providesKey,
                        final GridGlobalPreferences gridGlobalPreferences ) {
         super( providesKey, gridGlobalPreferences );
-        this.pageSize=pageSize;
-        this.dataGrid.setPageSize( pageSize );
-        this.pager.setDisplay( dataGrid );
-        setShowPageSizesSelector( showPageSizesSelector );
-        createPageSizesListBox(5,20,5);
+        init( pageSize, showPageSizesSelector );
     }
 
     public PagedTable( final int pageSize,
@@ -102,8 +90,14 @@ public class PagedTable<T>
                        final boolean showPageSizesSelector ) {
 
         super( providesKey, gridGlobalPreferences );
+        init( pageSize, showPageSizesSelector );
+    }
+
+    private void init( int pageSize,
+                       boolean showPageSizesSelector ) {
         this.pageSize=pageSize;
         this.dataGrid.setPageSize( pageSize );
+        this.pager.setPageSize( pageSize );
         this.pager.setDisplay( dataGrid );
         setShowPageSizesSelector( showPageSizesSelector );
         createPageSizesListBox(5,20,5);

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/SimpleTable.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/SimpleTable.java
@@ -16,6 +16,9 @@
 
 package org.uberfire.ext.widgets.common.client.tables;
 
+import java.util.List;
+import javax.inject.Inject;
+
 import com.github.gwtbootstrap.client.ui.Button;
 import com.github.gwtbootstrap.client.ui.DataGrid;
 import com.github.gwtbootstrap.client.ui.Label;
@@ -28,17 +31,29 @@ import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent;
 import com.google.gwt.user.cellview.client.ColumnSortList;
 import com.google.gwt.user.cellview.client.RowStyles;
-import com.google.gwt.user.client.ui.*;
-import com.google.gwt.view.client.*;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.HasWidgets;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.view.client.CellPreviewEvent;
 import com.google.gwt.view.client.CellPreviewEvent.Handler;
+import com.google.gwt.view.client.HasData;
+import com.google.gwt.view.client.ProvidesKey;
+import com.google.gwt.view.client.Range;
+import com.google.gwt.view.client.RangeChangeEvent;
+import com.google.gwt.view.client.RowCountChangeEvent;
+import com.google.gwt.view.client.SelectionModel;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.security.shared.api.identity.User;
-import org.uberfire.ext.services.shared.preferences.*;
+import org.uberfire.ext.services.shared.preferences.GridColumnPreference;
+import org.uberfire.ext.services.shared.preferences.GridGlobalPreferences;
+import org.uberfire.ext.services.shared.preferences.GridPreferencesStore;
+import org.uberfire.ext.services.shared.preferences.UserPreferencesService;
+import org.uberfire.ext.services.shared.preferences.UserPreferencesType;
 import org.uberfire.ext.widgets.common.client.resources.CommonResources;
-
-import javax.inject.Inject;
-import java.util.List;
 
 /**
  * A composite Widget that shows rows of data (not-paged) and a "column picker"
@@ -93,24 +108,29 @@ public class SimpleTable<T>
     private ProvidesKey<T> providersKey;
 
     public SimpleTable() {
-        dataGrid = new DataGrid<T>();
+        dataGrid = makeDataGrid();
         setupGridTable();
     }
 
     public SimpleTable( final ProvidesKey<T> providesKey,
                         final GridGlobalPreferences gridGlobalPreferences ) {
-
-        dataGrid = new DataGrid<T>( Integer.MAX_VALUE,
-                                    providesKey );
+        dataGrid = makeDataGrid( providesKey );
         this.gridPreferencesStore = new GridPreferencesStore( gridGlobalPreferences );
         setupGridTable();
     }
 
     public SimpleTable( final ProvidesKey<T> providesKey ) {
-
-        dataGrid = new DataGrid<T>( Integer.MAX_VALUE,
-                                    providesKey );
+        dataGrid = makeDataGrid( providesKey );
         setupGridTable();
+    }
+
+    protected DataGrid<T> makeDataGrid() {
+        return new DataGrid<T>();
+    }
+
+    protected DataGrid<T> makeDataGrid( ProvidesKey<T> providesKey ) {
+        return new DataGrid<T>( Integer.MAX_VALUE,
+                                    providesKey );
     }
 
     private void setupGridTable() {

--- a/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/PagedTableTest.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/PagedTableTest.java
@@ -1,0 +1,60 @@
+package org.uberfire.ext.widgets.common.client.tables;
+
+import com.github.gwtbootstrap.client.ui.DataGrid;
+import com.github.gwtbootstrap.client.ui.Label;
+import com.github.gwtbootstrap.client.ui.base.TextNode;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.view.client.ProvidesKey;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.ext.services.shared.preferences.GridGlobalPreferences;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+@WithClassesToStub({Image.class, Label.class, TextNode.class})
+public class PagedTableTest {
+
+    private PagedTable pagedTable;
+
+    @GwtMock
+    DataGrid dataGrid;
+
+    @Test
+    public void testConstructorWithSize() throws Exception {
+        this.pagedTable = new PagedTable( 5 ) {
+            @Override protected DataGrid makeDataGrid() {
+                return PagedTableTest.this.dataGrid;
+            }
+
+            @Override protected DataGrid makeDataGrid( ProvidesKey providesKey ) {
+                return PagedTableTest.this.dataGrid;
+            }
+        };
+
+        verify( dataGrid ).setPageSize( 5 );
+        verify( pagedTable.pager ).setPageSize( 5 );
+    }
+
+    @Test
+    public void testConstructorWithAllParameters() throws Exception {
+        this.pagedTable = new PagedTable( 10,
+                                          mock( ProvidesKey.class ),
+                                          new GridGlobalPreferences(),
+                                          false ) {
+            @Override protected DataGrid makeDataGrid() {
+                return PagedTableTest.this.dataGrid;
+            }
+
+            @Override protected DataGrid makeDataGrid( ProvidesKey providesKey ) {
+                return PagedTableTest.this.dataGrid;
+            }
+        };
+
+        verify( dataGrid ).setPageSize( 10 );
+        verify( pagedTable.pager ).setPageSize( 10 );
+    }
+}


### PR DESCRIPTION
I'm really really not a fan of the makeDataGrid methods in SimpleTable. But the version of GwtMockito we use currently does not support stubbing of the DataGrid. So the options were to either use a protected methods that can be overwritten in the test or upgrade gwtmockito just for this module (not sure if even the latest supports it, but the snapshot does).