### PR TITLE
BZ-1232000: if lucene parser returns an empty query - we use widlcard to

### DIFF
--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/search/LuceneSearchIndex.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/search/LuceneSearchIndex.java
@@ -157,6 +157,9 @@ public class LuceneSearchIndex implements SearchIndex {
         Query fullText;
         try {
             fullText = queryParser.parse( term );
+            if ( fullText.toString().isEmpty() ) {
+                fullText = new WildcardQuery( new Term( FULL_TEXT_FIELD, format( term ) + "*" ) );
+            }
         } catch ( ParseException ex ) {
             fullText = new WildcardQuery( new Term( FULL_TEXT_FIELD, format( term ) ) );
         }

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/IOSearchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/IOSearchIndexTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.metadata.io;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class IOSearchIndexTest extends BaseIndexTest {
+
+    @Override
+    protected String[] getRepositoryNames() {
+        return new String[]{ this.getClass().getSimpleName() };
+    }
+
+    @Test
+    public void testFullTextSearch() throws IOException, InterruptedException {
+
+        final IOSearchIndex searchIndex = new IOSearchIndex( config.getSearchIndex(), ioService() );
+
+        final Path path1 = getBasePath( this.getClass().getSimpleName() ).resolve( "a.txt" );
+        ioService().write( path1,
+                           "ooooo!" );
+
+        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+
+        {
+            final List<Path> result = searchIndex.fullTextSearch( "a", 10, 0, path1.getRoot() );
+
+            assertEquals( 1, result.size() );
+        }
+    }
+}

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneFullTextSearchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneFullTextSearchIndexTest.java
@@ -161,6 +161,37 @@ public class LuceneFullTextSearchIndexTest extends BaseIndexTest {
                           hits.length );
         }
 
+        {
+            final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+
+            searcher.search( new WildcardQuery( new Term( FULL_TEXT_FIELD, "*mydrlfile1*" ) ), collector );
+
+            final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+            listHitPaths( searcher,
+                          hits );
+
+            assertEquals( 1,
+                          hits.length );
+        }
+
+
+        final Path path2 = getBasePath( this.getClass().getSimpleName() ).resolve( "a.drl" );
+        ioService().write( path2,
+                           "Some cheese" );
+
+        {
+            final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+
+            searcher.search( new WildcardQuery( new Term( FULL_TEXT_FIELD, "a*" ) ), collector );
+
+            final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+            listHitPaths( searcher,
+                          hits );
+
+            assertEquals( 1,
+                          hits.length );
+        }
+
         ( (LuceneIndex) index ).nrtRelease( searcher );
     }
 


### PR DESCRIPTION
return possible results. Usually this happens when you try to search
with a single character.