### PR TITLE
BZ-1232000: removing the use of stop words from default analyzer -

### DIFF
--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/LuceneConfigBuilder.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/LuceneConfigBuilder.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.util.CharArraySet;
 import org.uberfire.ext.metadata.backend.lucene.analyzer.FilenameAnalyzer;
 import org.uberfire.ext.metadata.backend.lucene.fields.FieldFactory;
 import org.uberfire.ext.metadata.backend.lucene.fields.SimpleFieldFactory;
@@ -124,7 +125,7 @@ public final class LuceneConfigBuilder {
     }
 
     public void withDefaultAnalyzer() {
-        this.analyzer = new PerFieldAnalyzerWrapper( new StandardAnalyzer( LUCENE_40 ),
+        this.analyzer = new PerFieldAnalyzerWrapper( new StandardAnalyzer( LUCENE_40, CharArraySet.EMPTY_SET ),
                                                      new HashMap<String, Analyzer>() {{
                                                          putAll( analyzers );
                                                      }} );

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/search/LuceneSearchIndex.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/search/LuceneSearchIndex.java
@@ -157,6 +157,9 @@ public class LuceneSearchIndex implements SearchIndex {
         Query fullText;
         try {
             fullText = queryParser.parse( term );
+            if ( fullText.toString().isEmpty() ) {
+                fullText = new WildcardQuery( new Term( FULL_TEXT_FIELD, format( term ) + "*" ) );
+            }
         } catch ( ParseException ex ) {
             fullText = new WildcardQuery( new Term( FULL_TEXT_FIELD, format( term ) ) );
         }

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOSearchIndex.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOSearchIndex.java
@@ -18,17 +18,18 @@ package org.uberfire.ext.metadata.io;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.ext.metadata.search.ClusterSegment;
+import org.uberfire.ext.metadata.search.SearchIndex;
 import org.uberfire.io.IOSearchService;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.base.SegmentedPath;
 import org.uberfire.java.nio.file.Path;
-import org.uberfire.ext.metadata.model.KObject;
-import org.uberfire.ext.metadata.search.ClusterSegment;
-import org.uberfire.ext.metadata.search.SearchIndex;
 
 import static org.uberfire.commons.validation.PortablePreconditions.*;
 
@@ -38,7 +39,7 @@ import static org.uberfire.commons.validation.PortablePreconditions.*;
 public class IOSearchIndex implements IOSearchService {
 
     private final SearchIndex searchIndex;
-    private final IOService   ioService;
+    private final IOService ioService;
 
     public IOSearchIndex( final SearchIndex searchIndex,
                           final IOService ioService ) {
@@ -60,10 +61,14 @@ public class IOSearchIndex implements IOSearchService {
     }
 
     @Override
-    public List<Path> fullTextSearch( final String term,
+    public List<Path> fullTextSearch( final String _term,
                                       final int pageSize,
                                       final int startIndex,
                                       final Path... roots ) {
+        final String term = checkNotNull( "term", _term ).trim();
+        if ( term.isEmpty() ) {
+            return Collections.emptyList();
+        }
         final List<KObject> kObjects = searchIndex.fullTextSearch( term, pageSize, startIndex, buildClusterSegments( roots ) );
         return new ArrayList<Path>() {{
             for ( KObject kObject : kObjects ) {

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/IOSearchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/IOSearchIndexTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.metadata.io;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class IOSearchIndexTest extends BaseIndexTest {
+
+    @Override
+    protected String[] getRepositoryNames() {
+        return new String[]{ this.getClass().getSimpleName() };
+    }
+
+    @Test
+    public void testFullTextSearch() throws IOException, InterruptedException {
+
+        final IOSearchIndex searchIndex = new IOSearchIndex( config.getSearchIndex(), ioService() );
+
+        final Path path1 = getBasePath( this.getClass().getSimpleName() ).resolve( "g.txt" );
+        ioService().write( path1,
+                           "ooooo!" );
+
+        final Path path2 = getBasePath( this.getClass().getSimpleName() ).resolve( "a.txt" );
+        ioService().write( path2,
+                           "ooooo!" );
+
+        final Path path3 = getBasePath( this.getClass().getSimpleName() ).resolve( "the.txt" );
+        ioService().write( path3,
+                           "ooooo!" );
+
+        final Path root = path1.getRoot();
+
+        Thread.sleep( 5000 ); //wait for events to be consumed from jgit -> (notify changes -> watcher -> index) -> lucene index
+
+        {
+            final List<Path> result = searchIndex.fullTextSearch( "g", 10, 0, root );
+
+            assertEquals( 1, result.size() );
+        }
+
+        {
+            final List<Path> result = searchIndex.fullTextSearch( "a", 10, 0, root );
+
+            assertEquals( 1, result.size() );
+        }
+
+        {
+            final List<Path> result = searchIndex.fullTextSearch( "the", 10, 0, root );
+
+            assertEquals( 1, result.size() );
+        }
+
+        {
+            final List<Path> result = searchIndex.fullTextSearch( "", 10, 0, root );
+
+            assertEquals( 0, result.size() );
+        }
+
+        {
+            try {
+                searchIndex.fullTextSearch( null, 10, 0, root );
+                fail();
+            } catch ( final IllegalArgumentException ignored ) {
+            }
+        }
+    }
+}

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneFullTextSearchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneFullTextSearchIndexTest.java
@@ -161,6 +161,37 @@ public class LuceneFullTextSearchIndexTest extends BaseIndexTest {
                           hits.length );
         }
 
+        {
+            final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+
+            searcher.search( new WildcardQuery( new Term( FULL_TEXT_FIELD, "*mydrlfile1*" ) ), collector );
+
+            final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+            listHitPaths( searcher,
+                          hits );
+
+            assertEquals( 1,
+                          hits.length );
+        }
+
+
+        final Path path2 = getBasePath( this.getClass().getSimpleName() ).resolve( "a.drl" );
+        ioService().write( path2,
+                           "Some cheese" );
+
+        {
+            final TopScoreDocCollector collector = TopScoreDocCollector.create( 10, true );
+
+            searcher.search( new WildcardQuery( new Term( FULL_TEXT_FIELD, "a*" ) ), collector );
+
+            final ScoreDoc[] hits = collector.topDocs().scoreDocs;
+            listHitPaths( searcher,
+                          hits );
+
+            assertEquals( 1,
+                          hits.length );
+        }
+
         ( (LuceneIndex) index ).nrtRelease( searcher );
     }
 


### PR DESCRIPTION
default analyzer is used to index the fullText field. Now indexing  and
queries works as expected with stop words like "a" or "the"