### PR TITLE
Enhance CacheHeadersFilter to allow for caching of .cache.* files

### DIFF
--- a/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/CacheHeadersFilter.java
+++ b/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/CacheHeadersFilter.java
@@ -1,15 +1,22 @@
 package org.uberfire.ext.security.server;
 
 import java.io.IOException;
+import java.util.Calendar;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class CacheHeadersFilter implements Filter {
+    static final String EXPIRES_HEADER = "Expires";
+    static final String CACHE_CONTROL_HEADER = "Cache-Control";
+    static final String PRAGMA_HEADER = "Pragma";
+    static final int YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
 
     @Override
     public void init( final FilterConfig filterConfig ) throws ServletException {
@@ -23,9 +30,23 @@ public class CacheHeadersFilter implements Filter {
     public void doFilter( final ServletRequest request,
                           final ServletResponse response,
                           final FilterChain chain ) throws IOException, ServletException {
-        ( (HttpServletResponse) response ).setHeader( "Cache-Control", "no-cache, no-store, must-revalidate" ); // HTTP 1.1.
-        ( (HttpServletResponse) response ).setHeader( "Pragma", "no-cache" ); // HTTP 1.0.
-        ( (HttpServletResponse) response ).setDateHeader( "Expires", 0 ); // Proxies.
+
+        final HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        final HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+        final String requestURI = httpServletRequest.getRequestURI();
+        
+        if ( requestURI.contains( ".cache." ) ) {
+            final Calendar calendar = Calendar.getInstance();
+            calendar.add( Calendar.SECOND, YEAR_IN_SECONDS );
+
+            httpServletResponse.setHeader( CACHE_CONTROL_HEADER, "max-age=" + YEAR_IN_SECONDS + ", must-revalidate" );
+            httpServletResponse.setDateHeader( EXPIRES_HEADER, calendar.getTime().getTime() );
+        } 
+        else if ( requestURI.endsWith( ".nocache.js" ) || ( requestURI.endsWith( ".html" )) ) {
+            httpServletResponse.setHeader( CACHE_CONTROL_HEADER, "no-cache, no-store, must-revalidate" );
+            httpServletResponse.setHeader( PRAGMA_HEADER, "no-cache" );
+            httpServletResponse.setDateHeader( EXPIRES_HEADER, 0 );
+        }
 
         chain.doFilter( request, response );
     }

--- a/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/CacheHeadersFilterTest.java
+++ b/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/CacheHeadersFilterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.uberfire.ext.security.server.CacheHeadersFilter.CACHE_CONTROL_HEADER;
+import static org.uberfire.ext.security.server.CacheHeadersFilter.EXPIRES_HEADER;
+import static org.uberfire.ext.security.server.CacheHeadersFilter.PRAGMA_HEADER;
+
+import java.util.Calendar;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CacheHeadersFilterTest {
+
+    @Mock
+    private HttpServletRequest request;
+    
+    @Mock
+    private HttpServletResponse response;
+    
+    @Mock
+    private FilterChain chain;
+    
+    @Test
+    public void cacheFilesWithCacheExtension() throws Exception {
+        when(request.getRequestURI()).thenReturn("/app/hash.cache.js");
+
+        final CacheHeadersFilter filter = new CacheHeadersFilter();
+        filter.doFilter( request, response, chain );
+        verify(response).setHeader( CACHE_CONTROL_HEADER , "max-age=31536000, must-revalidate" );
+        
+        ArgumentCaptor<String> expiresHeader = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Long> expiresValue = ArgumentCaptor.forClass(Long.class);
+        verify(response).setDateHeader( expiresHeader.capture(), expiresValue.capture() );
+        assertEquals(EXPIRES_HEADER, expiresHeader.getValue());
+        
+        final Calendar expiryDate= Calendar.getInstance();
+        expiryDate.setTimeInMillis( expiresValue.getValue() );
+        final Calendar now = Calendar.getInstance();
+        long expiryInDays = (expiryDate.getTimeInMillis() - now.getTimeInMillis()) / (1000 * 60 * 60 * 24);
+        assertTrue(expiryInDays >= 364);
+    }
+    
+    @Test
+    public void doNotCacheFilesWithNoCacheExtension() throws Exception {
+        when(request.getRequestURI()).thenReturn("/app/abc.nocache.js");
+        verifyNoCache();
+    }
+    
+    @Test
+    public void doNotCacheHostPage() throws Exception {
+        when(request.getRequestURI()).thenReturn("/host-page.html");
+        verifyNoCache();
+    }
+    
+    private void verifyNoCache() throws Exception {
+        final CacheHeadersFilter filter = new CacheHeadersFilter();
+        filter.doFilter( request, response, chain );
+        
+        verify(response).setHeader( CACHE_CONTROL_HEADER , "no-cache, no-store, must-revalidate" );
+        verify(response).setDateHeader( EXPIRES_HEADER , 0 );
+        verify(response).setHeader( PRAGMA_HEADER , "no-cache" );
+    }
+}


### PR DESCRIPTION
Cherry picked from master for (newly created) https://bugzilla.redhat.com/show_bug.cgi?id=1283304

This makes the compiled permutations (*.cache.js) cacheable :) (because they are). When refreshing [1] or revisiting the host page, we will now get a 304 (Not Modified) and these files will be served from cache. Note that every new compile generates the *.cache.js permutation files with different hashes. This is on purpose so they are downloaded once after every compile/redeployment and we'll never end up with a cached version when a new one should be loaded.

This should significantly improve the loading time of our workbench over slow network connections. Of course, the host page and the *.nocache.js files are still not cached and downloaded every time.

More details here [2], expiry date was set to one year in the future as recommended by [3].

[1] regular refresh NOT ctrl->shift->r or any other cache invalidating reload
[2] https://www.mnot.net/cache_docs/
[3] https://www.ietf.org/rfc/rfc2616.txt