### PR TITLE
Filter out GWT client code from Wires WAR

### DIFF
--- a/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -466,6 +466,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <configuration>
+          <packagingExcludes>
+            **/*.gwt.xml,
+            WEB-INF/classes/**/client/**,
+            WEB-INF/classes/**/public/**
+          </packagingExcludes>
+          <archive>
+            <addMavenDescriptor>false</addMavenDescriptor>
+          </archive>
+        </configuration>
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Client side classes are not needed on server, plus they have some
dependencies which are not in WEB-INF/lib, which leads to LinkageError
on EAP.