### PR TITLE
Move to Errai 3.2.2-SNAPSHOT

### DIFF
--- a/uberfire-extensions-deps/pom.xml
+++ b/uberfire-extensions-deps/pom.xml
@@ -42,7 +42,7 @@
     <version.org.eclipse.jgit>3.7.1.201504261725-r</version.org.eclipse.jgit>
 
     <version.org.uberfire>0.8.0-SNAPSHOT</version.org.uberfire>
-    <version.org.jboss.errai>3.2.1-SNAPSHOT</version.org.jboss.errai>
+    <version.org.jboss.errai>3.2.2-SNAPSHOT</version.org.jboss.errai>
     <version.org.owasp.encoder>1.1</version.org.owasp.encoder>
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
     <version.jakarta-regexp>1.4</version.jakarta-regexp>


### PR DESCRIPTION
This commits move to the use of version 3.2.2-SNAPSHOT for Errai artifacts.

I have run the full build with tests, the wires webapp and i checked this fix against my users management webapp too, it works fine in all the scenarios. 

Thanks @csadilek !