### PR TITLE
Fix display name of the uberfire-apps project

### DIFF
--- a/uberfire-apps/pom.xml
+++ b/uberfire-apps/pom.xml
@@ -28,7 +28,7 @@
   <artifactId>uberfire-apps</artifactId>
   <packaging>pom</packaging>
 
-  <name>Uberfire Perspective Editor</name>
+  <name>Uberfire Apps</name>
 
   <modules>
     <module>uberfire-apps-api</module>


### PR DESCRIPTION
The previous name was result of a copy&paste error and it was a source of confusion when navigating project structure in an IDE.