### PR TITLE
GUVNOR-2302: Technical error message shown when trying to 'upload' assets without selecting a file

### DIFF
--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadBase.java
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadBase.java
@@ -73,21 +73,10 @@ public abstract class DefaultEditorFileUploadBase
 
         formEncoder.addUtf8Charset( form );
 
-        form.addSubmitHandler( new AbstractForm.SubmitHandler() {
-            @Override
-            public void onSubmit( final AbstractForm.SubmitEvent event ) {
-                String fileName = fileUpload.getFilename();
-                if ( isNullOrEmpty( fileName ) ) {
-                    Window.alert( CoreConstants.INSTANCE.SelectFileToUpload() );
-                    executeCallback( errorCallback );
-                    event.cancel();
-                }
-            }
-
-            private boolean isNullOrEmpty( String fileName ) {
-                return fileName == null || "".equals( fileName );
-            }
-        } );
+        // Validation is not performed in a SubmitHandler as it fails to be invoked with GWT-Bootstrap3. See:-
+        // - https://issues.jboss.org/browse/GUVNOR-2302 and
+        // - the underlying cause https://github.com/gwtbootstrap3/gwtbootstrap3/issues/375
+        // Validation is now performed prior to the form being submitted.
 
         form.addSubmitCompleteHandler( new AbstractForm.SubmitCompleteHandler() {
             @Override
@@ -109,9 +98,27 @@ public abstract class DefaultEditorFileUploadBase
             @Override
             public void execute() {
                 form.setAction( GWT.getModuleBaseURL() + "defaulteditor/upload" + createParametersForURL() );
-                form.submit();
+                if ( isValid() ) {
+                    form.submit();
+                }
             }
+
         }, showUpload );
+    }
+
+    //Package protected to support overriding for tests
+    boolean isValid() {
+        String fileName = fileUpload.getFilename();
+        if ( isNullOrEmpty( fileName ) ) {
+            Window.alert( CoreConstants.INSTANCE.SelectFileToUpload() );
+            executeCallback( errorCallback );
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isNullOrEmpty( String fileName ) {
+        return fileName == null || "".equals( fileName );
     }
 
     private String createParametersForURL() {

--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadBaseTestWrapper.java
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadBaseTestWrapper.java
@@ -16,13 +16,15 @@
 
 package org.uberfire.ext.widgets.core.client.editors.defaulteditor;
 
+import java.util.Collections;
 import java.util.Map;
 
-public class FileUploadEditor extends DefaultEditorFileUploadBase {
+public class DefaultEditorFileUploadBaseTestWrapper extends DefaultEditorFileUploadBase {
 
     boolean initialized;
+    boolean isValid;
 
-    public FileUploadEditor() {
+    public DefaultEditorFileUploadBaseTestWrapper() {
         super( false );
     }
 
@@ -38,9 +40,18 @@ public class FileUploadEditor extends DefaultEditorFileUploadBase {
         initForm();
     }
 
+    void setValid( final boolean isValid ) {
+        this.isValid = isValid;
+    }
+
+    @Override
+    boolean isValid() {
+        return isValid;
+    }
+
     @Override
     protected Map<String, String> getParameters() {
-        return null;
+        return Collections.emptyMap();
     }
 
 }

--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadTest.java
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.uberfire.ext.widgets.common.client.common.FileUploadFormEncoder;
+import org.uberfire.mvp.Command;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
@@ -35,13 +36,19 @@ import static org.mockito.Mockito.*;
 public class DefaultEditorFileUploadTest {
 
     @InjectMocks
-    private FileUploadEditor editor;
+    private DefaultEditorFileUploadBaseTestWrapper editor;
 
     @GwtMock
     private Form form;
 
     @Mock
     private FileUploadFormEncoder formEncoder;
+
+    @Mock
+    private Command successCallback;
+
+    @Mock
+    private Command errorCallback;
 
     @Before
     public void setup() {
@@ -50,13 +57,34 @@ public class DefaultEditorFileUploadTest {
 
     @Test
     public void formCharsetAdded() {
-        verify( formEncoder, times( 1 ) ).addUtf8Charset( form );
+        verify( formEncoder,
+                times( 1 ) ).addUtf8Charset( form );
     }
 
     @Test
     public void formSubmitHandlersSet() {
-        verify( form, times( 1 ) ).addSubmitHandler( any( SubmitHandler.class ) );
-        verify( form, times( 1 ) ).addSubmitCompleteHandler( any( SubmitCompleteHandler.class ) );
+        verify( form,
+                never() ).addSubmitHandler( any( SubmitHandler.class ) );
+        verify( form,
+                times( 1 ) ).addSubmitCompleteHandler( any( SubmitCompleteHandler.class ) );
+    }
+
+    @Test
+    public void formSubmitValidState() {
+        editor.setValid( true );
+        editor.upload( successCallback,
+                       errorCallback );
+        verify( form,
+                times( 1 ) ).submit();
+    }
+
+    @Test
+    public void formSubmitInvalidState() {
+        editor.setValid( false );
+        editor.upload( successCallback,
+                       errorCallback );
+        verify( form,
+                never() ).submit();
     }
 
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2302

The cause is the ```Form```'s ```SubmitHandler``` is broken in GWT-Bootstrap 3 (see https://github.com/gwtbootstrap3/gwtbootstrap3/issues/375). The issue is fixed in GWT-Bootstrap 3 0.9.2 (we're on 0.9.1 at the moment). The fix is a work-around to move form validation to before we submit the form. 