### PR TITLE
Livespark requirements on layout-editor implemented by pere

### DIFF
--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditor.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditor.java
@@ -20,6 +20,7 @@ import java.util.List;
 import com.google.gwt.user.client.ui.Widget;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.components.LayoutDragComponentGroup;
 
 public interface LayoutEditor {
 
@@ -36,4 +37,12 @@ public interface LayoutEditor {
     void addLayoutProperty(String key, String value);
 
     String getLayoutProperty(String key);
+
+    void addDraggableComponentGroup( LayoutDragComponentGroup group );
+
+    void addDraggableComponentToGroup( String groupId, String componentId, LayoutDragComponent component );
+
+    void removeDraggableComponentGroup ( String groupId );
+
+    void removeDraggableGroupComponent (String groupId, String componentId);
 }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorEntryPoint.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorEntryPoint.java
@@ -18,7 +18,6 @@ package org.uberfire.ext.layout.editor.client;
 
 import javax.annotation.PostConstruct;
 
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.ext.layout.editor.client.resources.WebAppResource;
 

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImpl.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImpl.java
@@ -29,6 +29,7 @@ import org.uberfire.ext.editor.commons.client.file.SaveOperationService;
 import org.uberfire.ext.layout.editor.api.LayoutServices;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.components.LayoutDragComponentGroup;
 import org.uberfire.ext.plugin.model.LayoutEditorModel;
 import org.uberfire.ext.plugin.model.PluginType;
 import org.uberfire.ext.plugin.service.PluginServices;
@@ -92,7 +93,7 @@ public class LayoutEditorPluginImpl implements LayoutEditorPlugin {
 
     @Override
     public void addLayoutProperty(String key, String value) {
-        layoutEditorPresenter.addLayoutProperty(key, value);
+        layoutEditorPresenter.addLayoutProperty( key, value );
     }
 
     @Override
@@ -142,16 +143,36 @@ public class LayoutEditorPluginImpl implements LayoutEditorPlugin {
 
     private void savePlugin(final String model, final Path path, final RemoteCallback<Path> saveSuccessCallback ) {
 
-        new SaveOperationService().save(path, new ParameterizedCommand<String>() {
+        new SaveOperationService().save( path, new ParameterizedCommand<String>() {
             @Override
             public void execute( final String commitMessage ) {
                 pluginServices.call( saveSuccessCallback ).saveLayout( getLayoutContent( path, model ),
-                        commitMessage );
+                                                                       commitMessage );
             }
-        });
+        } );
     }
 
     private LayoutEditorModel getLayoutContent(Path currentPath, String model) {
         return new LayoutEditorModel(pluginName, pluginType, currentPath, model);
+    }
+
+    @Override
+    public void addDraggableComponentGroup( LayoutDragComponentGroup group ) {
+        layoutEditorPresenter.addDraggableComponentGroup( group );
+    }
+
+    @Override
+    public void addDraggableComponentToGroup( String groupId, String componentId, LayoutDragComponent component ) {
+        layoutEditorPresenter.addDraggableComponentToGroup( groupId, componentId, component );
+    }
+
+    @Override
+    public void removeDraggableComponentGroup( String groupId ) {
+        layoutEditorPresenter.removeDraggableGroup( groupId );
+    }
+
+    @Override
+    public void removeDraggableGroupComponent( String groupId, String componentId ) {
+        layoutEditorPresenter.removeDraggableComponentFromGroup( groupId, componentId );
     }
 }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPresenter.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPresenter.java
@@ -15,6 +15,7 @@
  */
 package org.uberfire.ext.layout.editor.client;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -23,15 +24,20 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.Widget;
+import org.jboss.errai.ioc.client.container.IOC;
 import org.uberfire.client.mvp.UberView;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
+import org.uberfire.ext.layout.editor.client.components.LayoutDragComponentGroup;
 import org.uberfire.ext.layout.editor.client.structure.EditorWidget;
 import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.util.DragTypeBeanResolver;
 import org.uberfire.workbench.events.NotificationEvent;
 
 @Dependent
 public class LayoutEditorPresenter {
+
+    public static final String[] SPANS = {"12", "6 6", "4 4 4"};
 
     @Inject
     private Event<NotificationEvent> ufNotification;
@@ -65,6 +71,14 @@ public class LayoutEditorPresenter {
 
         void removeLayoutComponentProperty( EditorWidget component,
                                             String key );
+
+        void addDraggableComponentGroup( LayoutDragComponentGroup group );
+
+        void addDraggableComponentToGroup( String groupId, String componentId, LayoutDragComponent component );
+
+        void removeDraggableGroup( String id );
+
+        void removeDraggableComponentFromGroup( String groupId, String componentId );
     }
 
     @Inject
@@ -77,10 +91,17 @@ public class LayoutEditorPresenter {
     }
 
     public void setupDndPallete(List<LayoutDragComponent> layoutDragComponents ) {
-        view.setupComponents(layoutDragComponents);
-        view.setupGridSystem(Arrays.asList((LayoutDragComponent) new GridLayoutDragComponent("12", ufNotification),
-                new GridLayoutDragComponent("6 6", ufNotification),
-                new GridLayoutDragComponent("4 4 4", ufNotification)) );
+        view.setupComponents( layoutDragComponents );
+
+        List components = new ArrayList(  );
+
+        for ( String span : SPANS ) {
+            GridLayoutDragComponent component = IOC.getBeanManager().lookupBean( GridLayoutDragComponent.class ).newInstance();
+            component.setSpan( span );
+            components.add( component );
+        }
+
+        view.setupGridSystem( components );
     }
 
     public LayoutTemplate getLayout() {
@@ -96,11 +117,27 @@ public class LayoutEditorPresenter {
     }
 
     public void addLayoutProperty(String key, String value) {
-        view.addLayoutProperty(key, value);
+        view.addLayoutProperty( key, value );
     }
 
     public String getLayoutProperty(String key) {
-        return view.getLayoutProperty(key);
+        return view.getLayoutProperty( key );
+    }
+
+    public void addDraggableComponentGroup( LayoutDragComponentGroup group ) {
+        view.addDraggableComponentGroup( group );
+    }
+
+    public void addDraggableComponentToGroup( String groupId, String componentId, LayoutDragComponent component ) {
+        view.addDraggableComponentToGroup( groupId, componentId, component );
+    }
+
+    public void removeDraggableGroup( String id ) {
+        view.removeDraggableGroup( id );
+    }
+
+    public void removeDraggableComponentFromGroup( String groupId, String componentId ) {
+        view.removeDraggableComponentFromGroup( groupId, componentId );
     }
 }
 

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/DynamicLayoutDraggableGroup.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/DynamicLayoutDraggableGroup.java
@@ -1,0 +1,73 @@
+/*
+* Copyright 2015 JBoss Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.uberfire.ext.layout.editor.client.components;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Widget;
+import org.gwtbootstrap3.client.ui.Anchor;
+import org.gwtbootstrap3.client.ui.PanelBody;
+import org.gwtbootstrap3.client.ui.PanelCollapse;
+import org.uberfire.ext.layout.editor.client.dnd.DragGridElement;
+
+
+public class DynamicLayoutDraggableGroup extends Composite {
+    private Map<String, DragGridElement> elements = new HashMap<String, DragGridElement>(  );
+
+    interface DynamicLayoutDraggableGroupBinder
+            extends
+            UiBinder<Widget, DynamicLayoutDraggableGroup> {
+
+    }
+
+    private static DynamicLayoutDraggableGroupBinder uiBinder = GWT.create(DynamicLayoutDraggableGroupBinder.class);
+
+    @UiField
+    Anchor anchor;
+
+    @UiField
+    PanelCollapse collapse;
+
+    @UiField
+    PanelBody content;
+
+    public DynamicLayoutDraggableGroup( ) {
+        initWidget(uiBinder.createAndBindUi(this));
+        anchor.setDataTargetWidget( collapse );
+    }
+
+    public void setName( String name ) {
+        anchor.setText( name );
+    }
+
+    public void addDraggable( String id, DragGridElement gridElement) {
+        content.add( gridElement );
+        elements.put( id, gridElement );
+    }
+
+    public void removeDraggable( String id ) {
+        DragGridElement element = elements.remove( id );
+        if ( element != null ) {
+            content.remove( element );
+        }
+    }
+
+}

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/DynamicLayoutDraggableGroup.ui.xml
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/DynamicLayoutDraggableGroup.ui.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright 2015 JBoss Inc
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:b="urn:import:org.gwtbootstrap3.client.ui">
+
+  <ui:style>
+    .panelContent {
+      margin-bottom: 0px !important;
+    }
+  </ui:style>
+
+  <b:Panel addStyleNames="{style.panelContent}">
+    <b:PanelHeader>
+      <b:Heading size="H4">
+        <b:Anchor ui:field="anchor" dataToggle="COLLAPSE" icon="FOLDER"/>
+      </b:Heading>
+    </b:PanelHeader>
+    <b:PanelCollapse ui:field="collapse">
+      <b:PanelBody ui:field="content"/>
+    </b:PanelCollapse>
+  </b:Panel>
+
+</ui:UiBinder>

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/GridLayoutDragComponent.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/GridLayoutDragComponent.java
@@ -16,7 +16,9 @@
 
 package org.uberfire.ext.layout.editor.client.components;
 
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
+import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.BlurEvent;
@@ -27,19 +29,25 @@ import org.gwtbootstrap3.client.ui.constants.InputSize;
 import org.uberfire.ext.layout.editor.client.dnd.GridValueValidator;
 import org.uberfire.workbench.events.NotificationEvent;
 
-public class GridLayoutDragComponent extends InternalDragComponent {
+@Dependent
+public class GridLayoutDragComponent extends InternalDragComponent implements HasDragAndDropSettings {
 
-    private final Event<NotificationEvent> ufNotification;
+    public static final String SPAN = "span";
 
-    private String span;
+    private Event<NotificationEvent> ufNotification;
 
-    public GridLayoutDragComponent( final String span,
-                                    final Event<NotificationEvent> ufNotification ) {
-        this.span = span;
+    @Inject
+    public GridLayoutDragComponent( Event<NotificationEvent> ufNotification ) {
         this.ufNotification = ufNotification;
     }
 
-    public String label() {
+    private String span;
+
+    public void setSpan( String span ) {
+        this.span = span;
+    }
+
+    public String getSpan() {
         return span;
     }
 
@@ -70,5 +78,21 @@ public class GridLayoutDragComponent extends InternalDragComponent {
     private void returnToOldValue( String V,
                                    TextBox textBox ) {
         textBox.setText( V );
+    }
+
+    @Override
+    public String[] getSettingsKeys() {
+        return new String[]{ SPAN };
+    }
+
+    @Override
+    public String getSettingValue( String key ) {
+        if ( SPAN.equals( key ) ) return span;
+        return null;
+    }
+
+    @Override
+    public void setSettingValue( String key, String value ) {
+        if ( SPAN.equals( key ) ) span = value;
     }
 }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/HasDragAndDropSettings.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/HasDragAndDropSettings.java
@@ -1,0 +1,26 @@
+/*
+* Copyright 2015 JBoss Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.uberfire.ext.layout.editor.client.components;
+
+/**
+ * Interface to allow Drag & Drop Elements to have Default Setting that are going to be shared on the Drag & Drop
+ * events
+ */
+public interface HasDragAndDropSettings {
+    String[] getSettingsKeys();
+    String getSettingValue( String key );
+    void setSettingValue( String key, String value );
+}

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/HasOnDropNotification.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/HasOnDropNotification.java
@@ -1,0 +1,23 @@
+/*
+* Copyright 2015 JBoss Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.uberfire.ext.layout.editor.client.components;
+
+/**
+ * Interface that allows to notify when an element has been droped.
+ */
+public interface HasOnDropNotification {
+    void onDropComponent();
+}

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/HasOnRemoveNotification.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/HasOnRemoveNotification.java
@@ -1,0 +1,23 @@
+/*
+* Copyright 2015 JBoss Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.uberfire.ext.layout.editor.client.components;
+
+/**
+ * Interface that allows to notify when an element has been removed.
+ */
+public interface HasOnRemoveNotification {
+    void onRemoveComponent();
+}

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/LayoutComponentView.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/LayoutComponentView.java
@@ -17,9 +17,11 @@
 package org.uberfire.ext.layout.editor.client.components;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.*;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Panel;
@@ -31,7 +33,6 @@ import org.gwtbootstrap3.client.ui.constants.ColumnSize;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.client.dnd.DropColumnPanel;
-import org.uberfire.ext.layout.editor.client.resources.WebAppResource;
 import org.uberfire.ext.layout.editor.client.structure.ColumnEditorWidget;
 import org.uberfire.ext.layout.editor.client.structure.ComponentEditorWidget;
 import org.uberfire.ext.layout.editor.client.structure.EditorWidget;
@@ -148,7 +149,6 @@ public class LayoutComponentView extends Composite {
         remove.setSize( ButtonSize.EXTRA_SMALL );
         remove.setType( ButtonType.PRIMARY );
         remove.setIcon( IconType.EDIT );
-        remove.getElement().getStyle().setProperty( "marginRight", "3px" );
         remove.addClickHandler( new ClickHandler() {
             public void onClick( ClickEvent event ) {
                 showConfigurationScreen();
@@ -163,11 +163,11 @@ public class LayoutComponentView extends Composite {
 
         if ( type instanceof HasModalConfiguration ) {
             ModalConfigurationContext ctx = new ModalConfigurationContext( layoutComponent, fluidContainer, this );
-            Modal configModal = ( (HasModalConfiguration) type ).getConfigurationModal( ctx );
+            Modal configModal = ( ( HasModalConfiguration ) type ).getConfigurationModal( ctx );
             configModal.show();
         } else if ( type instanceof HasPanelConfiguration ) {
             PanelConfigurationContext ctx = new PanelConfigurationContext( layoutComponent, fluidContainer, this );
-            Panel configPanel = ( (HasPanelConfiguration) type ).getConfigurationPanel( ctx );
+            Panel configPanel = ( ( HasPanelConfiguration ) type ).getConfigurationPanel( ctx );
             componentEditorWidget.getWidget().clear();
             componentEditorWidget.getWidget().add( configPanel );
         }
@@ -194,6 +194,9 @@ public class LayoutComponentView extends Composite {
         parent.getWidget().getElement().getStyle().clearWidth();
         parent.getWidget().getElement().getStyle().clearHeight();
         componentEditorWidget.removeFromParent();
+        if ( type instanceof HasOnRemoveNotification ) {
+            ( ( HasOnRemoveNotification ) type ).onRemoveComponent();
+        }
     }
 
     private void addDropColumnPanel() {
@@ -204,7 +207,7 @@ public class LayoutComponentView extends Composite {
         EditorWidget target = parent;
         while ( target != null ) {
             if ( target instanceof LayoutEditorWidget ) {
-                return (LayoutEditorWidget) target;
+                return ( LayoutEditorWidget ) target;
             }
             target = target.getParent();
         }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/LayoutDragComponentGroup.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/LayoutDragComponentGroup.java
@@ -1,0 +1,46 @@
+/*
+* Copyright 2015 JBoss Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.uberfire.ext.layout.editor.client.components;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class LayoutDragComponentGroup {
+    private String name;
+    private Map<String, LayoutDragComponent> components = new HashMap<String, LayoutDragComponent>(  );
+
+    public LayoutDragComponentGroup( String name ) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void addLayoutDragComponent(String id, LayoutDragComponent component) {
+        components.put( id, component );
+    }
+
+    public Set<String> getLayoutDragComponentIds() {
+        return components.keySet();
+    }
+
+    public LayoutDragComponent getLayoutDragComponent( String id ) {
+        return components.get( id );
+    }
+
+}

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DndData.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DndData.java
@@ -28,7 +28,7 @@ public class DndData {
 
     public static String generateData( LayoutDragComponent type ) {
         if ( type instanceof GridLayoutDragComponent ) {
-            return prepareData( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT, ( ( GridLayoutDragComponent ) type ).label() );
+            return prepareData( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT, ( ( GridLayoutDragComponent ) type ).getSpan() );
         } else {
             return prepareData( LayoutDragComponent.class.toString(), type.getClass().getName() );
         }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DragGridElement.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DragGridElement.java
@@ -22,16 +22,16 @@ import com.google.gwt.event.dom.client.DragStartHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Element;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.InputGroup;
-import org.uberfire.ext.layout.editor.client.resources.i18n.CommonConstants;
-import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
-import org.uberfire.ext.layout.editor.client.components.InternalDragComponent;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.dnd.impl.DndDataJSONConverter;
+import org.uberfire.ext.layout.editor.client.resources.i18n.CommonConstants;
 
 public class DragGridElement extends Composite {
+
+    private DndDataJSONConverter converter = new DndDataJSONConverter();
 
     private LayoutDragComponent type;
 
@@ -64,7 +64,7 @@ public class DragGridElement extends Composite {
     void createDragStart( DragStartEvent event,
                           LayoutDragComponent type ) {
 
-        event.setData( DndData.FORMAT,  DndData.generateData( type ) );
+        event.setData( DndData.FORMAT,  converter.generateDragComponentJSON( type ) );
 
         event.getDataTransfer().setDragImage( move.getElement(), 10, 10 );
     }
@@ -79,4 +79,7 @@ public class DragGridElement extends Composite {
 
     private static MyUiBinder uiBinder = GWT.create( MyUiBinder.class );
 
+    public void setConverter( DndDataJSONConverter converter ) {
+        this.converter = converter;
+    }
 }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DropColumnPanel.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DropColumnPanel.java
@@ -17,25 +17,20 @@
 package org.uberfire.ext.layout.editor.client.dnd;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.DragLeaveEvent;
-import com.google.gwt.event.dom.client.DragLeaveHandler;
-import com.google.gwt.event.dom.client.DragOverEvent;
-import com.google.gwt.event.dom.client.DragOverHandler;
-import com.google.gwt.event.dom.client.DropEvent;
-import com.google.gwt.event.dom.client.DropHandler;
+import com.google.gwt.event.dom.client.*;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.FlowPanel;
 import org.gwtbootstrap3.client.ui.Label;
-import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
-import org.uberfire.ext.layout.editor.client.components.LayoutComponentView;
+import org.uberfire.ext.layout.editor.client.components.*;
+import org.uberfire.ext.layout.editor.client.dnd.impl.DndDataJSONConverter;
 import org.uberfire.ext.layout.editor.client.resources.WebAppResource;
 import org.uberfire.ext.layout.editor.client.row.RowView;
 import org.uberfire.ext.layout.editor.client.structure.ColumnEditorWidget;
 import org.uberfire.ext.layout.editor.client.util.DragTypeBeanResolver;
-import org.uberfire.ext.layout.editor.client.components.InternalDragComponent;
-import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
 
 public class DropColumnPanel extends FlowPanel {
+
+    private DndDataJSONConverter converter = new DndDataJSONConverter();
 
     private final ColumnEditorWidget parent;
 
@@ -71,22 +66,22 @@ public class DropColumnPanel extends FlowPanel {
     void dropHandler( DropEvent event ) {
         event.preventDefault();
 
-        if ( isInternalDragComponent( DndData.getEventType( event ) ) ) {
-            handleGridDrop( DndData.getEventData( event ) );
+        LayoutDragComponent component = converter.readJSONDragComponent( event.getData( DndData.FORMAT ) );
+
+        if ( component instanceof GridLayoutDragComponent ) {
+            handleGridDrop( ((GridLayoutDragComponent) component).getSpan() );
         } else {
-            handleExternalLayoutDragComponent( DndData.getEventData( event ) );
+            handleExternalLayoutDragComponent( component );
         }
 
         dragLeaveHandler();
     }
 
-    private boolean isInternalDragComponent( String eventType ) {
-        return !eventType.isEmpty() && eventType.equalsIgnoreCase( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT );
-    }
-
-    private void handleExternalLayoutDragComponent( String dragTypeClassName ) {
-        LayoutDragComponent layoutDragComponent = getLayoutDragComponent( dragTypeClassName );
+    private void handleExternalLayoutDragComponent( LayoutDragComponent layoutDragComponent ) {
         if ( layoutDragComponent != null ) {
+            if ( layoutDragComponent instanceof HasOnDropNotification ) {
+                ( ( HasOnDropNotification ) layoutDragComponent ).onDropComponent();
+            }
             handleLayoutDrop( layoutDragComponent );
         }
     }
@@ -135,4 +130,7 @@ public class DropColumnPanel extends FlowPanel {
         return addBitlessDomHandler( handler, DragLeaveEvent.getType() );
     }
 
+    public void setConverter( DndDataJSONConverter converter ) {
+        this.converter = converter;
+    }
 }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DropRowPanel.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/DropRowPanel.java
@@ -27,19 +27,22 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.FlowPanel;
 import org.gwtbootstrap3.client.ui.Label;
 import org.uberfire.ext.layout.editor.client.components.GridLayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.dnd.impl.DndDataJSONConverter;
 import org.uberfire.ext.layout.editor.client.resources.WebAppResource;
 import org.uberfire.ext.layout.editor.client.row.RowView;
 import org.uberfire.ext.layout.editor.client.structure.LayoutEditorWidget;
-import org.uberfire.ext.layout.editor.client.components.InternalDragComponent;
 
 public class DropRowPanel extends FlowPanel {
+
+    private DndDataJSONConverter converter = new DndDataJSONConverter();
 
     private final LayoutEditorWidget parent;
 
     public DropRowPanel( final LayoutEditorWidget parent ) {
         this.parent = parent;
 
-        Label label = GWT.create(Label.class);
+        Label label = GWT.create( Label.class );
         label.setText("New row ...");
         this.add(label);
 
@@ -66,14 +69,13 @@ public class DropRowPanel extends FlowPanel {
 
     void dropHandler( DropEvent event ) {
         event.preventDefault();
-        if ( isInternalDragComponent( DndData.getEventType( event ) ) ) {
-            handleGridDrop( DndData.getEventData( event ) );
+
+        LayoutDragComponent component = converter.readJSONDragComponent( event.getData( DndData.FORMAT ) );
+
+        if ( component instanceof GridLayoutDragComponent ) {
+            handleGridDrop( ((GridLayoutDragComponent) component).getSpan() );
         }
         dragLeaveHandler();
-    }
-
-    private boolean isInternalDragComponent( String eventType ) {
-        return !eventType.isEmpty() && eventType.equalsIgnoreCase( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT );
     }
 
     void dragOverHandler() {
@@ -126,4 +128,7 @@ public class DropRowPanel extends FlowPanel {
         return addBitlessDomHandler( handler, DragLeaveEvent.getType() );
     }
 
+    public void setConverter( DndDataJSONConverter converter ) {
+        this.converter = converter;
+    }
 }

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/impl/DndDataJSONConverter.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/dnd/impl/DndDataJSONConverter.java
@@ -1,0 +1,84 @@
+/*
+* Copyright 2015 JBoss Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*       http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.uberfire.ext.layout.editor.client.dnd.impl;
+
+import javax.enterprise.context.Dependent;
+
+import com.google.gwt.json.client.JSONObject;
+import com.google.gwt.json.client.JSONParser;
+import com.google.gwt.json.client.JSONString;
+import org.uberfire.ext.layout.editor.client.components.HasDragAndDropSettings;
+import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+import org.uberfire.ext.layout.editor.client.util.DragTypeBeanResolver;
+
+@Dependent
+public class DndDataJSONConverter {
+
+    public static final String COMPONENT_TYPE = "type";
+    public static final String COMPONENT_PARAMS = "params";
+
+    private DragTypeBeanResolver beanResolver = new DragTypeBeanResolver();
+
+    public String generateDragComponentJSON( LayoutDragComponent dragComponent ) {
+        JSONObject jsonComponent = new JSONObject();
+        jsonComponent.put( COMPONENT_TYPE, new JSONString( dragComponent.getClass().getName() ) );
+
+        if ( dragComponent instanceof HasDragAndDropSettings ) {
+            JSONObject params = new JSONObject(  );
+
+            HasDragAndDropSettings sComponent = ( HasDragAndDropSettings ) dragComponent;
+
+            for ( String key : sComponent.getSettingsKeys() ) {
+                String value = sComponent.getSettingValue( key );
+                params.put( key, new JSONString( value ) );
+            }
+
+            jsonComponent.put( COMPONENT_PARAMS, params );
+        }
+
+        return jsonComponent.toString();
+    }
+
+    public LayoutDragComponent readJSONDragComponent( String json ) {
+        JSONObject jsonObject = JSONParser.parseStrict( json ).isObject();
+
+        JSONString typeValue = jsonObject.get( COMPONENT_TYPE ).isString();
+        if ( typeValue != null ) {
+            String type = typeValue.stringValue();
+
+            LayoutDragComponent dragComponent = beanResolver.lookupDragTypeBean( type );
+
+            if ( dragComponent instanceof HasDragAndDropSettings ) {
+                HasDragAndDropSettings sComponent = ( HasDragAndDropSettings ) dragComponent;
+
+                JSONObject params = jsonObject.get( COMPONENT_PARAMS ).isObject();
+
+                if ( params != null ) {
+                    for ( String key : params.keySet() ) {
+                        JSONString value = params.get( key ).isString();
+                        if ( value != null ) {
+                            sComponent.setSettingValue( key, value.stringValue() );
+                        }
+                    }
+                }
+            }
+
+            return dragComponent;
+        }
+
+        return null;
+    }
+}

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/generator/BootstrapLayoutGenerator.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/generator/BootstrapLayoutGenerator.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.AttachEvent;
@@ -43,6 +44,7 @@ import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.components.RenderingContext;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
 import org.uberfire.ext.layout.editor.client.row.RowView;
+import org.uberfire.ext.layout.editor.client.util.DragTypeBeanResolver;
 
 /**
  * A bootstrap based layout generator
@@ -50,23 +52,12 @@ import org.uberfire.ext.layout.editor.client.row.RowView;
 @ApplicationScoped
 public class BootstrapLayoutGenerator implements LayoutGenerator {
 
-    protected Map<String,LayoutDragComponent> _dragComponents = new HashMap<String, LayoutDragComponent>();
 
-    @AfterInitialization
-    public void init() {
-        Collection<IOCBeanDef<LayoutDragComponent>> beanDefs = IOC.getBeanManager().lookupBeans(LayoutDragComponent.class);
-        for (IOCBeanDef<LayoutDragComponent> beanDef : beanDefs) {
-            try {
-                _dragComponents.put(beanDef.getBeanClass().getName(), beanDef.getInstance());
-            } catch (Exception e) {
-                GWT.log("Bean failed", e);
-            }
-        }
-    }
+    @Inject
+    private DragTypeBeanResolver dragTypeBeanResolver;
 
     public Container build(LayoutTemplate layoutTemplate) {
         Container mainPanel = new Container();
-        mainPanel.setFluid( true );
         mainPanel.getElement().setId( "mainContainer" );
         List<LayoutRow> rows = layoutTemplate.getRows();
         generateRows(rows, mainPanel);
@@ -92,7 +83,7 @@ public class BootstrapLayoutGenerator implements LayoutGenerator {
     private void generateComponents(final LayoutColumn layoutColumn, final Column column) {
         for (final LayoutComponent layoutComponent : layoutColumn.getLayoutComponents() ) {
 
-            final LayoutDragComponent dragComponent = _dragComponents.get(layoutComponent.getDragTypeName());
+            final LayoutDragComponent dragComponent = dragTypeBeanResolver.lookupDragTypeBean(layoutComponent.getDragTypeName());
             if (dragComponent != null) {
                 RenderingContext componentContext = new RenderingContext(layoutComponent, column);
                 IsWidget componentWidget = dragComponent.getShowWidget(componentContext);

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/ColumnEditorWidget.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/ColumnEditorWidget.java
@@ -16,11 +16,11 @@
 
 package org.uberfire.ext.layout.editor.client.structure;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.google.gwt.user.client.ui.ComplexPanel;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ColumnEditorWidget implements EditorWidget {
 
@@ -47,6 +47,11 @@ public class ColumnEditorWidget implements EditorWidget {
 
     public ComplexPanel getWidget() {
         return container;
+    }
+
+    @Override
+    public List<EditorWidget> getChildren() {
+        return childs;
     }
 
     @Override

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/ComponentEditorWidget.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/ComponentEditorWidget.java
@@ -19,6 +19,8 @@ package org.uberfire.ext.layout.editor.client.structure;
 import com.google.gwt.user.client.ui.ComplexPanel;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
 
+import java.util.List;
+
 public class ComponentEditorWidget implements EditorWidget {
 
     private final EditorWidget parent;
@@ -46,6 +48,11 @@ public class ComponentEditorWidget implements EditorWidget {
 
     public void removeFromParent() {
         parent.removeChild( this );
+    }
+
+    @Override
+    public List<EditorWidget> getChildren() {
+        return null;
     }
 
     @Override

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/EditorWidget.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/EditorWidget.java
@@ -19,11 +19,15 @@ package org.uberfire.ext.layout.editor.client.structure;
 import com.google.gwt.user.client.ui.ComplexPanel;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
 
+import java.util.List;
+
 public interface EditorWidget {
 
     ComplexPanel getWidget();
 
     EditorWidget getParent();
+
+    List<EditorWidget> getChildren();
 
     void addChild( EditorWidget editorWidget );
 

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/LayoutEditorWidget.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/LayoutEditorWidget.java
@@ -16,18 +16,17 @@
 
 package org.uberfire.ext.layout.editor.client.structure;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.enterprise.context.ApplicationScoped;
-
 import com.google.gwt.user.client.ui.ComplexPanel;
-import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
 import org.uberfire.ext.layout.editor.client.util.LayoutTemplateAdapter;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @ApplicationScoped
 public class LayoutEditorWidget implements EditorWidget {
@@ -64,6 +63,11 @@ public class LayoutEditorWidget implements EditorWidget {
     @Override
     public ComplexPanel getWidget() {
         return container;
+    }
+
+    @Override
+    public List<EditorWidget> getChildren() {
+        return rowEditors;
     }
 
     @Override

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/RowEditorWidget.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/structure/RowEditorWidget.java
@@ -16,11 +16,12 @@
 
 package org.uberfire.ext.layout.editor.client.structure;
 
+import com.google.gwt.user.client.ui.ComplexPanel;
+import org.uberfire.ext.layout.editor.client.components.HasOnRemoveNotification;
+import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
+
 import java.util.ArrayList;
 import java.util.List;
-
-import com.google.gwt.user.client.ui.ComplexPanel;
-import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
 
 public class RowEditorWidget implements EditorWidget {
 
@@ -67,13 +68,33 @@ public class RowEditorWidget implements EditorWidget {
         }
     }
 
+    @Override
+    public List<EditorWidget> getChildren() {
+        return columnEditors;
+    }
+
     public void addChild( EditorWidget columnEditor ) {
         columnEditors.add( columnEditor );
     }
 
     public void removeFromParent() {
         parent.removeChild( this );
+        notifyChildRemoval( columnEditors );
 
+    }
+
+
+    protected void notifyChildRemoval( List<EditorWidget> childEditors ) {
+        if ( childEditors == null ) return;
+
+        for ( EditorWidget editor : childEditors ) {
+
+            if ( editor.getType() instanceof HasOnRemoveNotification ) {
+                ( ( HasOnRemoveNotification ) editor.getType() ).onRemoveComponent();
+            }
+
+            if ( editor.getChildren() != null ) notifyChildRemoval( editor.getChildren() );
+        }
     }
 
     @Override

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/util/DragTypeBeanResolver.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/util/DragTypeBeanResolver.java
@@ -25,12 +25,10 @@ import org.uberfire.ext.layout.editor.client.components.LayoutDragComponent;
 
 public class DragTypeBeanResolver {
 
-    private Collection<IOCBeanDef<LayoutDragComponent>> iocBeanDefs;
 
     public LayoutDragComponent lookupDragTypeBean( String dragTypeClassName ) {
         SyncBeanManagerImpl beanManager = (SyncBeanManagerImpl) IOC.getBeanManager();
-        iocBeanDefs = beanManager.lookupBeans( LayoutDragComponent.class );
-
+        Collection<IOCBeanDef<LayoutDragComponent>> iocBeanDefs = beanManager.lookupBeans( LayoutDragComponent.class );
         for ( IOCBeanDef<LayoutDragComponent> iocBeanDef : iocBeanDefs ) {
             final LayoutDragComponent instance = iocBeanDef.getInstance();
             if ( instance.getClass().getName().equalsIgnoreCase( dragTypeClassName ) ) {

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DndDataTest.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DndDataTest.java
@@ -36,7 +36,7 @@ public class DndDataTest {
     DropEvent externalEvent;
 
     private final String INTERNAL_TYPE = "INTERNAL_DRAG_COMPONENT";
-    private final String INTERNAL_VALUE = "label";
+    private final String INTERNAL_VALUE = "getSpan";
     private final String INTERNAL_DATA = prepareData( INTERNAL_TYPE, INTERNAL_VALUE );
 
     private final String EXTERNAL_TYPE = "interface org.uberfire.ext.layout.editor.client.components.LayoutDragComponent";
@@ -47,7 +47,7 @@ public class DndDataTest {
     @Before
     public void setup() {
         internal = mock( GridLayoutDragComponent.class );
-        when( internal.label() ).thenReturn( "label" );
+        when( internal.getSpan() ).thenReturn( "span" );
         external = new DummyLayoutDragComponent();
 
         internalEvent = mock( DropEvent.class );

--- a/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DragGridElementTest.java
+++ b/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/dnd/DragGridElementTest.java
@@ -57,9 +57,9 @@ public class DragGridElementTest {
 
     @Test
     public void createDragStartInternalComponent() throws Exception {
-        String data = prepareData( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT, "label" );
+        String data = prepareData( GridLayoutDragComponent.INTERNAL_DRAG_COMPONENT, "span" );
         DragStartEvent dragStartEvent = mock( DragStartEvent.class );
-        when( internalType.label() ).thenReturn( "label" );
+        when( internalType.getSpan() ).thenReturn( "span" );
 
         final DataTransfer mock = mock( DataTransfer.class );
         when( mock.getData( DndData.FORMAT ) ).thenReturn( data );

--- a/uberfire-wires/uberfire-wires-webapp/src/main/webapp/WEB-INF/beans.xml
+++ b/uberfire-wires/uberfire-wires-webapp/src/main/webapp/WEB-INF/beans.xml
@@ -2,6 +2,9 @@
 
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="all">
   <scan>
+    <!-- These exclusions were added by Errai to avoid deploying client-side classes to the server -->
+    <!-- End of Errai exclusions -->
+
     <exclude name="org.uberfire.ext.wires.client.**"/>
     <exclude name="org.uberfire.ext.wires.core.trees.client.**"/>
     <exclude name="org.uberfire.ext.apps.client.**"/>


### PR DESCRIPTION
HasDragAndDropSettings: send other information information across the Drag & Drop event, not only the draggable type
HasOnDropNotification: notify the draggable component that’s been droved
HasOnRemoveNotification: notify the draggable component that’s going to be removed
DynamicLayoutDraggableGroup: allow to add / remove dynamic component groups on the components palette. Also allow to add / remove child elements of the dynamic groups.
BootstrapLayoutGenerator: lookup new DraggableComponent iinstances before render them.


There is no enought coverage in that PR, basically because part of this code will be changed in the  new layout editor version (my next task). I'll cover it and also extract MVP on it in my next pr.