### PR TITLE
BZ1192831: User with no privileges for Repository can view and modify assets in that Repository

### DIFF
--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/search/LuceneSearchIndex.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/search/LuceneSearchIndex.java
@@ -68,6 +68,9 @@ public class LuceneSearchIndex implements SearchIndex {
                                         final int pageSize,
                                         final int startIndex,
                                         final ClusterSegment... clusterSegments ) {
+        if ( clusterSegments == null || clusterSegments.length == 0 ) {
+            return emptyList();
+        }
         if ( attrs == null || attrs.size() == 0 ) {
             return emptyList();
         }
@@ -79,12 +82,18 @@ public class LuceneSearchIndex implements SearchIndex {
                                          final int pageSize,
                                          final int startIndex,
                                          final ClusterSegment... clusterSegments ) {
+        if ( clusterSegments == null || clusterSegments.length == 0 ) {
+            return emptyList();
+        }
         return search( buildQuery( term, clusterSegments ), pageSize, startIndex, clusterSegments );
     }
 
     @Override
     public int searchByAttrsHits( final Map<String, ?> attrs,
                                   final ClusterSegment... clusterSegments ) {
+        if ( clusterSegments == null || clusterSegments.length == 0 ) {
+            return 0;
+        }
         if ( attrs == null || attrs.size() == 0 ) {
             return 0;
         }
@@ -94,6 +103,9 @@ public class LuceneSearchIndex implements SearchIndex {
     @Override
     public int fullTextSearchHits( final String term,
                                    final ClusterSegment... clusterSegments ) {
+        if ( clusterSegments == null || clusterSegments.length == 0 ) {
+            return 0;
+        }
         return searchHits( buildQuery( term, clusterSegments ), clusterSegments );
     }
 

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneSearchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneSearchIndexTest.java
@@ -18,9 +18,11 @@ package org.uberfire.ext.metadata.io;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
+import org.uberfire.ext.metadata.model.KObject;
 import org.uberfire.ext.metadata.search.ClusterSegment;
 import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.base.SegmentedPath;
@@ -76,32 +78,110 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
                  "*.txt" );
         }};
 
+        //Attribute Search
         {
             final int hits = config.getSearchIndex().searchByAttrsHits( attributes );
-            assertEquals( 2,
+            final List<KObject> results = config.getSearchIndex().searchByAttrs( attributes,
+                                                                                 10,
+                                                                                 0 );
+            assertEquals( 0,
                           hits );
+            assertEquals( 0,
+                          results.size() );
         }
 
         {
             final int hits = config.getSearchIndex().searchByAttrsHits( attributes,
                                                                         cs1 );
+            final List<KObject> results = config.getSearchIndex().searchByAttrs( attributes,
+                                                                                 10,
+                                                                                 0,
+                                                                                 cs1 );
             assertEquals( 1,
                           hits );
+            assertEquals( 1,
+                          results.size() );
         }
 
         {
             final int hits = config.getSearchIndex().searchByAttrsHits( attributes,
                                                                         cs2 );
+            final List<KObject> results = config.getSearchIndex().searchByAttrs( attributes,
+                                                                                 10,
+                                                                                 0,
+                                                                                 cs2 );
             assertEquals( 1,
                           hits );
+            assertEquals( 1,
+                          results.size() );
         }
 
         {
             final int hits = config.getSearchIndex().searchByAttrsHits( attributes,
                                                                         cs1,
                                                                         cs2 );
+            final List<KObject> results = config.getSearchIndex().searchByAttrs( attributes,
+                                                                                 10,
+                                                                                 0,
+                                                                                 cs1,
+                                                                                 cs2 );
             assertEquals( 2,
                           hits );
+            assertEquals( 2,
+                          results.size() );
+        }
+
+        //Full Text Search
+        {
+            final int hits = config.getSearchIndex().fullTextSearchHits( "*indexed*" );
+            final List<KObject> results = config.getSearchIndex().fullTextSearch( "*indexed*",
+                                                                                  10,
+                                                                                  0 );
+            assertEquals( 0,
+                          hits );
+            assertEquals( 0,
+                          results.size() );
+        }
+
+        {
+            final int hits = config.getSearchIndex().fullTextSearchHits( "*indexed*",
+                                                                         cs1 );
+            final List<KObject> results = config.getSearchIndex().fullTextSearch( "*indexed*",
+                                                                                  10,
+                                                                                  0,
+                                                                                  cs1 );
+            assertEquals( 1,
+                          hits );
+            assertEquals( 1,
+                          results.size() );
+        }
+
+        {
+            final int hits = config.getSearchIndex().fullTextSearchHits( "*indexed*",
+                                                                         cs2 );
+            final List<KObject> results = config.getSearchIndex().fullTextSearch( "*indexed*",
+                                                                                  10,
+                                                                                  0,
+                                                                                  cs2 );
+            assertEquals( 1,
+                          hits );
+            assertEquals( 1,
+                          results.size() );
+        }
+
+        {
+            final int hits = config.getSearchIndex().fullTextSearchHits( "*indexed*",
+                                                                         cs1,
+                                                                         cs2 );
+            final List<KObject> results = config.getSearchIndex().fullTextSearch( "*indexed*",
+                                                                                  10,
+                                                                                  0,
+                                                                                  cs1,
+                                                                                  cs2 );
+            assertEquals( 2,
+                          hits );
+            assertEquals( 2,
+                          results.size() );
         }
     }
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1192831#c38

If no ```ClusterSegments``` are provided we searched *all* ```ClusterSegments``` leading to searches when the User is not authorised to access *any* Repository actually returning results from *all* Repositories. Making this change to uberfire-extensions is my preferred option as it ensures all current and future scenarios are covered (i.e. *all* searching in KIE Workbench should be scoped to the Repositories to which the User has access).

@porcelli @csadilek @ederign Thoughts please!