### PR TITLE
Fixes to launch webapp without errors.

### DIFF
--- a/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -32,7 +32,6 @@
   <description>Wires WebApp</description>
 
   <properties>
-    <errai.version>${version.org.jboss.errai}</errai.version>
     <as.version>8.1.0.Final</as.version>
     <!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
     <errai.jboss.home>${project.build.directory}/wildfly-${as.version}</errai.jboss.home>

--- a/uberfire-wires/uberfire-wires-webapp/src/main/webapp/WEB-INF/beans.xml
+++ b/uberfire-wires/uberfire-wires-webapp/src/main/webapp/WEB-INF/beans.xml
@@ -5,19 +5,21 @@
     <!-- These exclusions were added by Errai to avoid deploying client-side classes to the server -->
     <!-- End of Errai exclusions -->
 
-    <exclude name="org.uberfire.ext.wires.client.**"/>
-    <exclude name="org.uberfire.ext.wires.core.trees.client.**"/>
+    <exclude name="org.uberfire.client.**"/>
     <exclude name="org.uberfire.ext.apps.client.**"/>
     <exclude name="org.uberfire.ext.editor.commons.client.**"/>
     <exclude name="org.uberfire.ext.plugin.client.**"/>
+    <exclude name="org.uberfire.ext.widgets.core.client.**"/>
     <exclude name="org.uberfire.ext.widgets.common.client.**"/>
-    <exclude name="org.uberfire.ext.wires.bayesian.network.client.**"/>
     <exclude name="org.uberfire.ext.widgets.sandbox.client.**"/>
     <exclude name="org.uberfire.ext.properties.editor.client.**"/>
-    <exclude name="org.uberfire.ext.widgets.core.client.**"/>
-    <exclude name="org.uberfire.ext.wires.core.scratchpad.client.**"/>
-    <exclude name="org.uberfire.ext.wires.core.client.**"/>
+
+    <exclude name="org.uberfire.ext.wires.client.**"/>
     <exclude name="org.uberfire.ext.wires.core.api.**"/>
+    <exclude name="org.uberfire.ext.wires.core.client.**"/>
+    <exclude name="org.uberfire.ext.wires.core.scratchpad.client.**"/>
+    <exclude name="org.uberfire.ext.wires.core.trees.client.**"/>
     <exclude name="org.uberfire.ext.wires.bpmn.client.**"/>
+    <exclude name="org.uberfire.ext.wires.bayesian.network.client.**"/>
   </scan>
 </beans>


### PR DESCRIPTION
```<errai.version>``` property is not used following change to ```pom``` hierarchy.

The ```beans.xml``` file was missing a few exclusions following different peoples' different changes.
