### PR TITLE
Avoid running concurrent batch indexing threads for the same FS

### DIFF
--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/BatchIndex.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/BatchIndex.java
@@ -150,6 +150,8 @@ public final class BatchIndex {
                                                     attrs );
 
                                       if ( !file.getFileName().toString().startsWith( "." ) ) {
+                                          
+                                          LOG.debug( "Indexing " + file.toUri() );
 
                                           //Default indexing
                                           for ( final Class<? extends FileAttributeView> view : views ) {

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
@@ -361,7 +361,7 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
         } );
     }
 
-    private void indexIfFresh( final FileSystem fs ) {
+    private synchronized void indexIfFresh( final FileSystem fs ) {
         final KCluster cluster = KObjectUtil.toKCluster( fs );
         if ( indexEngine.freshIndex( cluster ) ) {
             // See https://bugzilla.redhat.com/show_bug.cgi?id=1288132


### PR DESCRIPTION
This fixes the intermittent test failures of BatchIndexConcurrencyTest [1]
and improves the fix for BZ-1288132 [2]

[1] https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/uberfire-extensions/186/org.uberfire$uberfire-metadata-commons-io/testReport/org.uberfire.ext.metadata.io/BatchIndexConcurrenyTest/testForSingleBatchIndexExecution/
[2] 7d6764e