### PR TITLE
BZ-1197649 - Validation inline on copying and renaming plugins.

### DIFF
--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/CopyPopup.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/CopyPopup.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.uberfire.ext.editor.commons.client.file;
 
 import org.jboss.errai.ioc.client.container.IOC;
@@ -110,5 +111,4 @@ public class CopyPopup implements CopyPopupView.Presenter {
     private static CopyPopupView getDefaultView() {
         return IOC.getBeanManager().lookupBean( CopyPopupView.class ).getInstance();
     }
-
 }

--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/RenamePopup.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/RenamePopup.java
@@ -16,27 +16,28 @@
 
 package org.uberfire.ext.editor.commons.client.file;
 
-import com.google.gwt.user.client.Window;
-import org.gwtbootstrap3.client.ui.TextBox;
-import org.gwtbootstrap3.client.ui.constants.ButtonType;
-import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.ioc.client.container.IOC;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.ext.editor.commons.client.resources.i18n.CommonConstants;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
 import org.uberfire.ext.editor.commons.client.validation.ValidatorCallback;
-import org.uberfire.ext.widgets.common.client.common.popups.FormStylePopup;
-import org.uberfire.ext.widgets.common.client.common.popups.footers.GenericModalFooter;
-import org.uberfire.mvp.Command;
 
 import static org.uberfire.commons.validation.PortablePreconditions.*;
 
-public class RenamePopup extends FormStylePopup {
+public class RenamePopup implements RenamePopupView.Presenter {
 
-    final private TextBox nameTextBox = new TextBox();
-    final private TextBox checkInCommentTextBox = new TextBox();
+    private final RenamePopupView view;
+    private final Path path;
+    private final Validator validator;
+    private final CommandWithFileNameAndCommitMessage command;
 
-    public RenamePopup( final Path path,
-                        final CommandWithFileNameAndCommitMessage command ) {
+    public RenamePopup( Path path,
+                        CommandWithFileNameAndCommitMessage command ) {
+        this( path, command, getDefaultView() );
+    }
+
+    public RenamePopup( Path path,
+                        CommandWithFileNameAndCommitMessage command,
+                        RenamePopupView view ) {
         this( path,
               new Validator() {
                   @Override
@@ -45,69 +46,69 @@ public class RenamePopup extends FormStylePopup {
                       callback.onSuccess();
                   }
               },
-              command );
+              command, view );
     }
 
-    public RenamePopup( final Path path,
-                        final Validator validator,
-                        final CommandWithFileNameAndCommitMessage command ) {
-        super( CommonConstants.INSTANCE.RenamePopupTitle() );
-
-        checkNotNull( "validator",
-                      validator );
-        checkNotNull( "path",
-                      path );
-        checkNotNull( "command",
-                      command );
-
-        //Make sure it appears on top of other popups
-        getElement().getStyle().setZIndex( Integer.MAX_VALUE );
-
-        nameTextBox.setTitle( CommonConstants.INSTANCE.NewName() );
-        addAttribute( CommonConstants.INSTANCE.NewNameColon(),
-                      nameTextBox );
-
-        checkInCommentTextBox.setTitle( CommonConstants.INSTANCE.CheckInComment() );
-        addAttribute( CommonConstants.INSTANCE.CheckInCommentColon(),
-                      checkInCommentTextBox );
-
-        final GenericModalFooter footer = new GenericModalFooter();
-        footer.addButton( CommonConstants.INSTANCE.RenamePopupRenameItem(),
-                          new Command() {
-                              @Override
-                              public void execute() {
-                                  final String baseFileName = nameTextBox.getText();
-                                  final String originalFileName = path.getFileName();
-                                  final String extension = ( originalFileName.lastIndexOf( "." ) > 0 ? originalFileName.substring( originalFileName.lastIndexOf( "." ) ) : "" );
-                                  final String fileName = baseFileName + extension;
-
-                                  validator.validate( fileName,
-                                                      new ValidatorCallback() {
-                                                          @Override
-                                                          public void onSuccess() {
-                                                              hide();
-                                                              command.execute( new FileNameAndCommitMessage( baseFileName,
-                                                                                                             checkInCommentTextBox.getText() ) );
-                                                          }
-
-                                                          @Override
-                                                          public void onFailure() {
-                                                              Window.alert( CommonConstants.INSTANCE.InvalidFileName0( baseFileName ) );
-                                                          }
-                                                      } );
-                              }
-                          },
-                          IconType.SAVE,
-                          ButtonType.PRIMARY );
-        footer.addButton( CommonConstants.INSTANCE.Cancel(),
-                          new Command() {
-                              @Override
-                              public void execute() {
-                                  hide();
-                              }
-                          },
-                          ButtonType.DEFAULT );
-        add( footer );
+    public RenamePopup( Path path,
+                        Validator validator,
+                        CommandWithFileNameAndCommitMessage command ) {
+        this( path, validator, command, getDefaultView() );
     }
 
+    public RenamePopup( Path path,
+                        Validator validator,
+                        CommandWithFileNameAndCommitMessage command,
+                        RenamePopupView view ) {
+        this.validator = checkNotNull( "validator",
+                                       validator );
+        this.path = checkNotNull( "path",
+                                  path );
+        this.command = checkNotNull( "command",
+                                     command );
+        this.view = checkNotNull( "view",
+                                  view );
+
+        this.view.init( this );
+    }
+
+    public void show() {
+        view.show();
+    }
+
+    private void hide() {
+        view.hide();
+    }
+
+    @Override
+    public void onCancel() {
+        hide();
+    }
+
+    @Override
+    public void onRename() {
+        final String baseFileName = view.getName();
+        final String originalFileName = path.getFileName();
+        final String extension = ( originalFileName.lastIndexOf( "." ) > 0
+                ? originalFileName.substring( originalFileName.lastIndexOf( "." ) ) : "" );
+        final String fileName = baseFileName + extension;
+
+        validator.validate( fileName,
+                            new ValidatorCallback() {
+                                @Override
+                                public void onSuccess() {
+                                    hide();
+                                    command.execute( new FileNameAndCommitMessage( baseFileName,
+                                                                                   view.getCheckInComment() ) );
+                                }
+
+                                @Override
+                                public void onFailure() {
+                                    view.handleInvalidFileName( baseFileName );
+                                }
+                            } );
+    }
+
+    private static RenamePopupView getDefaultView() {
+        return IOC.getBeanManager().lookupBean( RenamePopupView.class ).getInstance();
+    }
 }

--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/RenamePopupView.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/RenamePopupView.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file;
+
+import org.uberfire.client.mvp.UberView;
+
+public interface RenamePopupView extends UberView<RenamePopupView.Presenter> {
+
+    interface Presenter {
+
+        void onCancel();
+
+        void onRename();
+    }
+
+    String getName();
+
+    String getCheckInComment();
+
+    void handleInvalidFileName( String baseFileName );
+
+    void show();
+
+    void hide();
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/RenamePopupViewImpl.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/RenamePopupViewImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 JBoss, by Red Hat, Inc
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.uberfire.ext.widgets.common.client.common.popups.footers.GenericModal
 import org.uberfire.mvp.Command;
 
 @Dependent
-public class CopyPopupViewImpl extends FormStylePopup implements CopyPopupView {
+public class RenamePopupViewImpl extends FormStylePopup implements RenamePopupView {
 
     private final TextBox nameTextBox = new TextBox();
     private final TextBox checkInCommentTextBox = new TextBox();
@@ -43,8 +43,8 @@ public class CopyPopupViewImpl extends FormStylePopup implements CopyPopupView {
 
     private Presenter presenter;
 
-    public CopyPopupViewImpl() {
-        super( CommonConstants.INSTANCE.CopyPopupTitle() );
+    public RenamePopupViewImpl() {
+        super( CommonConstants.INSTANCE.RenamePopupTitle() );
 
         //Make sure it appears on top of other popups
         getElement().getStyle().setZIndex( Integer.MAX_VALUE );
@@ -61,12 +61,12 @@ public class CopyPopupViewImpl extends FormStylePopup implements CopyPopupView {
 
         hide();
 
-        GenericModalFooter footer = new GenericModalFooter();
-        footer.addButton( CommonConstants.INSTANCE.CopyPopupCreateACopy(),
+        final GenericModalFooter footer = new GenericModalFooter();
+        footer.addButton( CommonConstants.INSTANCE.RenamePopupRenameItem(),
                           new Command() {
                               @Override
                               public void execute() {
-                                  presenter.onCopy();
+                                  presenter.onRename();
                               }
                           },
                           IconType.SAVE,
@@ -83,12 +83,12 @@ public class CopyPopupViewImpl extends FormStylePopup implements CopyPopupView {
     }
 
     @Override
-    public void init( Presenter presenter ) {
+    public void init( RenamePopupView.Presenter presenter ) {
         this.presenter = presenter;
     }
 
     @Override
-    public String getNewName() {
+    public String getName() {
         return nameTextBox.getText();
     }
 
@@ -98,7 +98,7 @@ public class CopyPopupViewImpl extends FormStylePopup implements CopyPopupView {
     }
 
     @Override
-    public void handleInvalidFileName( String baseFileName ) {
+    public void handleInvalidFileName( final String baseFileName ) {
         nameFormStyleItem.getFormGroup().setValidationState( ValidationState.ERROR );
 
         // This message may need changing for different asset types; see https://bugzilla.redhat.com/show_bug.cgi?id=1197649#c4

--- a/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/RenamePopupTest.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/RenamePopupTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.editor.commons.client.file;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.client.validation.ValidatorCallback;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
+public class RenamePopupTest {
+
+    private static final String NAME_TEXT = "new name";
+    private static final String COMMENT_TEXT = "hello world";
+    private static final String PATH = "dir/file.ext";
+
+    private Validator successValidator;
+    private Validator failureValidator;
+
+    @Mock
+    private RenamePopupView view;
+    @Mock
+    private Path path;
+    @Mock
+    private CommandWithFileNameAndCommitMessage command;
+    @Captor
+    private ArgumentCaptor<FileNameAndCommitMessage> msgCaptor;
+
+    @Before
+    public void setUp() {
+
+        // stub mocks
+        when( path.getFileName() ).thenReturn( PATH );
+        when( view.getCheckInComment() ).thenReturn( COMMENT_TEXT );
+        when( view.getName() ).thenReturn( NAME_TEXT );
+
+        // set up testing validators
+        // it is easier to set up real objects than stubbing validate() method but we need to spy them
+        // to verify validation was invoked
+        successValidator = spy( new Validator() {
+            @Override
+            public void validate( String value, ValidatorCallback callback ) {
+                callback.onSuccess();
+            }
+        } );
+        failureValidator = spy( new Validator() {
+            @Override
+            public void validate( String value, ValidatorCallback callback ) {
+                callback.onFailure();
+            }
+        } );
+    }
+
+    @Test
+    public void testSuccessfulValidation() {
+        // popup with succesful validation
+        RenamePopup popup = new RenamePopup( path, successValidator, command, view );
+
+        // simulate submitting the popup
+        popup.onRename();
+
+        // validation was invoked
+        verify( successValidator ).validate( any( String.class ), any( ValidatorCallback.class ) );
+        // command was executed
+        verify( command ).execute( msgCaptor.capture() );
+        // check contents of the message passed to the command
+        assertThat( msgCaptor.getValue().getNewFileName(), CoreMatchers.equalTo( NAME_TEXT ) );
+        assertThat( msgCaptor.getValue().getCommitMessage(), CoreMatchers.equalTo( COMMENT_TEXT ) );
+        // dialog was hidden
+        verify( view ).hide();
+    }
+
+    @Test
+    public void testFailedValidation() {
+        // popup with failing validation
+        RenamePopup popup = new RenamePopup( path, failureValidator, command, view );
+
+        // simulate submitting the popup
+        popup.onRename();
+
+        // verify validation was invoked
+        verify( failureValidator ).validate( anyString(), any( ValidatorCallback.class ) );
+        // verify command was NOT executed
+        verify( command, never() ).execute( any( FileNameAndCommitMessage.class ) );
+        // popup stays active so that user can correct the input
+        verify( view, never() ).hide();
+        // view handles the failure message
+        verify( view ).handleInvalidFileName( NAME_TEXT );
+    }
+
+    @Test
+    public void testPopupCanceled() {
+        // popup with successful validation
+        RenamePopup popup = new RenamePopup( path, successValidator, command, view );
+
+        // simulate cancelling the popup
+        popup.onCancel();
+
+        // validation was NOT invoked
+        verify( successValidator, never() ).validate( anyString(), any( ValidatorCallback.class ) );
+        // command was NOT executed
+        verify( command, never() ).execute( any( FileNameAndCommitMessage.class ) );
+        // dialog was hidden
+        verify( view ).hide();
+    }
+
+    @Test
+    public void testDefaultValidator() {
+        // return some crazy values that shouldn't pass any validation
+        when( view.getName() ).thenReturn( null );
+        when( view.getCheckInComment() ).thenReturn( null );
+
+        // popup with a default validator
+        RenamePopup popup = new RenamePopup( path, command, view );
+
+        // simulate submitting the popup
+        popup.onRename();
+
+        // command was executed
+        verify( command ).execute( msgCaptor.capture() );
+        // check contents of the message passed to the command
+        assertThat( msgCaptor.getValue().getNewFileName(), CoreMatchers.nullValue() );
+        assertThat( msgCaptor.getValue().getCommitMessage(), CoreMatchers.nullValue() );
+        // dialog was hidden
+        verify( view ).hide();
+    }
+}

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FormStyleItem.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FormStyleItem.java
@@ -23,15 +23,21 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
+import org.gwtbootstrap3.client.ui.FormGroup;
 import org.gwtbootstrap3.client.ui.FormLabel;
 
 public class FormStyleItem extends Composite {
+
+    @UiField
+    FormGroup formGroup;
 
     @UiField
     FlowPanel group;
 
     @UiField
     FormLabel label;
+
+    int index = -1;
 
     interface FormStyleLayoutBinder
             extends
@@ -46,9 +52,22 @@ public class FormStyleItem extends Composite {
     }
 
     public void setup( final String labelText,
-                       final IsWidget field ) {
+                       final IsWidget field,
+                       final int index ) {
         label.setText( labelText );
         group.add( field );
+        this.index = index;
     }
 
+    public FormGroup getFormGroup() {
+        return this.formGroup;
+    }
+
+    public FlowPanel getGroup() {
+        return this.group;
+    }
+
+    public int getIndex() {
+        return this.index;
+    }
 }

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FormStyleItem.ui.xml
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FormStyleItem.ui.xml
@@ -21,7 +21,7 @@
              xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
              xmlns:g="urn:import:com.google.gwt.user.client.ui">
 
-    <b:FormGroup>
+    <b:FormGroup ui:field="formGroup">
         <b:Column size="MD_3">
             <b:FormLabel ui:field="label"/>
         </b:Column>

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FormStyleLayout.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/FormStyleLayout.java
@@ -46,12 +46,12 @@ public class FormStyleLayout extends Form {
         }} );
     }
 
-    public int addAttribute( String label,
+    public FormStyleItem addAttribute( String label,
                              IsWidget widget ) {
         final FormStyleItem formStyleItem = GWT.create( FormStyleItem.class );
-        formStyleItem.setup( label, widget );
+        formStyleItem.setup( label, widget, getWidgetCount() );
         add( formStyleItem );
-        return getWidgetCount() - 1;
+        return formStyleItem;
     }
 
     public int addRow( final IsWidget widget ) {

--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/FormStylePopup.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/popups/FormStylePopup.java
@@ -25,6 +25,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.ModalHeader;
 import org.gwtbootstrap3.client.ui.constants.HeadingSize;
+import org.uberfire.ext.widgets.common.client.common.FormStyleItem;
 import org.uberfire.ext.widgets.common.client.common.FormStyleLayout;
 
 /**
@@ -64,17 +65,17 @@ public class FormStylePopup extends BaseModal {
         this.form.clear();
     }
 
-    public int addAttribute( final String label,
-                             final IsWidget wid ) {
+    public FormStyleItem addAttribute( final String label,
+                                       final IsWidget wid ) {
         return form.addAttribute( label, wid );
     }
 
-    public int addAttribute( final String label,
+    public FormStyleItem addAttribute( final String label,
                              final IsWidget wid,
                              final boolean visible ) {
-        int index = form.addAttribute( label, wid );
-        setAttributeVisibility( index, visible );
-        return index;
+        FormStyleItem formStyleItem = form.addAttribute( label, wid );
+        setAttributeVisibility( formStyleItem.getIndex(), visible );
+        return formStyleItem;
     }
 
     public int addRow( final IsWidget wid ) {


### PR DESCRIPTION
The only thing left to resolve the BZ-1197649 ticket is to change the validation message accordingly to the ticket description, which I will do soon. Only making the PR now to avoid conflict in the meantime.

I also did a refactoring on the rename popup to separate the view from the presenter. Now this popup is very similar to the copy popup. They can be unified in the future much easier.