### PR TITLE
Additional fixes for BatchIndexConcurrencyTest (details below)

### DIFF
--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexEngine.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexEngine.java
@@ -67,10 +67,7 @@ public class LuceneIndexEngine implements MetaIndexEngine {
     @Override
     public boolean freshIndex( final KCluster cluster ) {
         final Index index = indexManager.get( cluster );
-        if ( index == null ) {
-            return !batchMode.containsKey( cluster );
-        }
-        return index.freshIndex();
+        return (index == null || index.freshIndex()) && !batchMode.containsKey( cluster );
     }
 
     @Override

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexManager.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexManager.java
@@ -19,10 +19,10 @@ package org.uberfire.ext.metadata.backend.lucene.index;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiReader;
@@ -40,7 +40,7 @@ import static org.uberfire.commons.validation.Preconditions.*;
 public class LuceneIndexManager implements IndexManager {
 
     private final LuceneIndexFactory factory;
-    private final Map<KCluster, LuceneIndex> indexes = new HashMap<KCluster, LuceneIndex>();
+    private final Map<KCluster, LuceneIndex> indexes = new ConcurrentHashMap<KCluster, LuceneIndex>();
 
     public LuceneIndexManager( final LuceneIndexFactory factory ) {
         this.factory = checkNotNull( "factory", factory );

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/BaseIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/BaseIndexTest.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.ext.metadata.io;
 
+import static org.uberfire.ext.metadata.backend.lucene.util.KObjectUtil.toKObject;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -37,16 +39,15 @@ import org.uberfire.ext.metadata.model.KObject;
 import org.uberfire.io.IOService;
 import org.uberfire.io.attribute.DublinCoreView;
 import org.uberfire.java.nio.base.version.VersionAttributeView;
+import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
 import org.uberfire.java.nio.file.Path;
-
-import static org.uberfire.ext.metadata.backend.lucene.util.KObjectUtil.*;
 
 public abstract class BaseIndexTest {
 
     private int seed = new Random( 10L ).nextInt();
 
     protected boolean created = false;
-    protected Map<String, Path> basePaths = new HashMap<String, Path>();
+    protected static final Map<String, Path> basePaths = new HashMap<String, Path>();
 
     protected LuceneConfig config;
     protected IOService ioService = null;
@@ -109,16 +110,17 @@ public abstract class BaseIndexTest {
                     basePaths.put( repositoryName,
                                    basePath );
 
-                } catch ( final Exception ex ) {
-                    ex.fillInStackTrace();
-                    System.out.println( ex.getMessage() );
-                } finally {
+                } 
+                catch ( final FileSystemAlreadyExistsException ex ) {
+                    // ignored
+                } 
+                finally {
                     created = true;
                 }
             }
         }
     }
-
+    
     protected abstract String[] getRepositoryNames();
 
     protected Path getBasePath( final String repositoryName ) {


### PR DESCRIPTION
- Default indexing thread for created test file no longer
interfering with the indexing threads under test

- Fixed indexFresh check to account for the fact that
an index could have been created (!=null) but the
corresponding indexing job is still in progress in which
case we also don't want to start another indexing thread

- These fixes are in addition to the earlier fix that made
indexIfFresh synchronized