### PR TITLE
Decrease memory settings for GWT compiler

### DIFF
--- a/uberfire-security/uberfire-security-management/uberfire-security-management-webapp/pom.xml
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-webapp/pom.xml
@@ -359,7 +359,7 @@
           <strict>true</strict>
           <localWorkers>1</localWorkers>
           <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
-          <extraJvmArgs>-Xmx2048m -XX:MaxPermSize=256m -Xms1024m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Dorg.uberfire.ext.security.management.api.userManagementServices=WildflyCLIUserManagementService -Dorg.uberfire.ext.security.management.wildfly.cli.host=localhost -Dorg.uberfire.ext.security.management.wildfly.cli.port=9990 -Dorg.uberfire.ext.security.management.wildfly.cli.user=admin -Dorg.uberfire.ext.security.management.wildfly.cli.password=admin -Dorg.uberfire.ext.security.management.wildfly.cli.realm=ApplicationRealm</extraJvmArgs>
+          <extraJvmArgs>-Xmx1g -XX:MaxPermSize=256m -Xms512m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Dorg.uberfire.ext.security.management.api.userManagementServices=WildflyCLIUserManagementService -Dorg.uberfire.ext.security.management.wildfly.cli.host=localhost -Dorg.uberfire.ext.security.management.wildfly.cli.port=9990 -Dorg.uberfire.ext.security.management.wildfly.cli.user=admin -Dorg.uberfire.ext.security.management.wildfly.cli.password=admin -Dorg.uberfire.ext.security.management.wildfly.cli.realm=ApplicationRealm</extraJvmArgs>
           <module>org.uberfire.ext.security.management.FastCompiledUberfireSecurityManagementShowcase</module>
           <logLevel>INFO</logLevel>
           <noServer>false</noServer>
@@ -525,7 +525,7 @@
               <module>org.uberfire.ext.security.management.UberfireSecurityManagementShowcase</module>
               <draftCompile>false</draftCompile>
               <localWorkers>4</localWorkers>
-              <extraJvmArgs>-Xmx4096m -XX:MaxPermSize=256m -Xms2048m -XX:PermSize=128m -Xss1M</extraJvmArgs>
+              <extraJvmArgs>-Xmx1g -XX:MaxPermSize=256m -Xms512m -XX:PermSize=128m -Xss1M</extraJvmArgs>
             </configuration>
           </plugin>
         </plugins>

--- a/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -399,7 +399,7 @@
           <strict>true</strict>
           <localWorkers>1</localWorkers>
           <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
-          <extraJvmArgs>-Xmx2048m -XX:MaxPermSize=256m -Xms1024m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
+          <extraJvmArgs>-Xmx1g -XX:MaxPermSize=256m -Xms512m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
           <module>org.uberfire.ext.wires.WiresShowcase</module>
           <logLevel>INFO</logLevel>
           <noServer>false</noServer>
@@ -583,7 +583,7 @@
               <module>org.uberfire.ext.wires.WiresShowcase</module>
               <draftCompile>false</draftCompile>
               <localWorkers>4</localWorkers>
-              <extraJvmArgs>-Xmx4096m -XX:MaxPermSize=256m -Xms2048m -XX:PermSize=128m -Xss1M</extraJvmArgs>
+              <extraJvmArgs>-Xmx1g -XX:MaxPermSize=256m -Xms512m -XX:PermSize=128m -Xss1M</extraJvmArgs>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
 * 1g is more than enough for these small showcases.
   Tested with mvn clean gwt:run