### PR TITLE
Fix duplicated classes

### DIFF
--- a/uberfire-security/uberfire-security-management/uberfire-security-management-tomcat/pom.xml
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-tomcat/pom.xml
@@ -82,11 +82,27 @@
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-catalina</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-coyote</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
 * these Tomcat libs bring in javax.* classes which
   are present also in the standard deps (like servlet-api)

@romartin could you please look at this? I am not exactly sure abut the excludes.