### PR TITLE
Fix bean manager use so that only a single PerspectiveEditorActivity …

### DIFF
--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/generator/PerspectiveEditorGenerator.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/generator/PerspectiveEditorGenerator.java
@@ -136,24 +136,18 @@ public class PerspectiveEditorGenerator {
         PerspectiveEditorScreenActivity activity = new PerspectiveEditorScreenActivity( perspective, layoutGenerator );
 
         final Set<Annotation> qualifiers = new HashSet<Annotation>( Arrays.asList( DEFAULT_QUALIFIERS ) );
-        beanManager.registerBean( new SingletonBeanDef<Activity, PerspectiveEditorScreenActivity>( activity,
-                                                                                                   Activity.class,
-                                                                                                   qualifiers,
-                                                                                                   activity.getIdentifier(),
-                                                                                                   true,
-                                                                                                   true ) );
-        beanManager.registerBean( new SingletonBeanDef<WorkbenchScreenActivity, PerspectiveEditorScreenActivity>( activity,
-                                                                                                   WorkbenchScreenActivity.class,
-                                                                                                   qualifiers,
-                                                                                                   activity.getIdentifier(),
-                                                                                                   true,
-                                                                                                   true ) );
-        beanManager.registerBean( new SingletonBeanDef<PerspectiveEditorScreenActivity, PerspectiveEditorScreenActivity>( activity,
-                                                                                                   PerspectiveEditorScreenActivity.class,
-                                                                                                   qualifiers,
-                                                                                                   activity.getIdentifier(),
-                                                                                                   true,
-                                                                                                   true ) );
+        final SingletonBeanDef<PerspectiveEditorScreenActivity, PerspectiveEditorScreenActivity> beanDef =
+                new SingletonBeanDef<PerspectiveEditorScreenActivity, PerspectiveEditorScreenActivity>(
+                        activity,
+                        PerspectiveEditorScreenActivity.class,
+                        qualifiers,
+                        activity.getIdentifier(),
+                        true,
+                        true );
+
+        beanManager.registerBean( beanDef );
+        beanManager.registerBeanTypeAlias( beanDef, Activity.class );
+        beanManager.registerBeanTypeAlias( beanDef, WorkbenchScreenActivity.class );
 
         activityBeansCache.addNewScreenActivity( beanManager.lookupBeans( activity.getIdentifier() ).iterator().next() );
         return activity;


### PR DESCRIPTION
…can be looked up.

In the previous usage, IOC.getBeanManager().lookupBeans(PerspectiveEditorActivity.class)
would return 3 bean defs with a reference to the same activity.