### PR TITLE
GUVNOR-2373: Modal for artifacts table in Project editor-Dependencies is too small for the content

### DIFF
--- a/uberfire-widgets/uberfire-widgets-commons/src/main/resources/org/uberfire/ext/widgets/common/client/resources/css/common.css
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/resources/org/uberfire/ext/widgets/common/client/resources/css/common.css
@@ -164,6 +164,7 @@
     background-color: #FFFFFF;
     padding: 5px;
     border: 1px solid #d1d1d1;
+    z-index: 2000;
 }
 
 @external .checkbox;


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2373

This PR just ensures the "Column Picker" appears on top of ```BaseModal``` for when tables are nested in a popup.