### PR TITLE
[0.8.x] BZ1304659: File Explorer: Package is expanded only after second click

### DIFF
--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/tree/TreeItem.java
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/tree/TreeItem.java
@@ -18,6 +18,7 @@ package org.uberfire.ext.widgets.core.client.tree;
 
 import java.util.Iterator;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -38,11 +39,11 @@ public class TreeItem extends Composite {
     private Object userObject;
     private TreeItem parent;
 
-    public static enum Type {
+    public enum Type {
         ROOT, FOLDER, ITEM, LOADING
     }
 
-    public static enum State {
+    public enum State {
         NONE, OPEN, CLOSE
     }
 
@@ -63,7 +64,7 @@ public class TreeItem extends Composite {
             folder.setStylePrimaryName( TreeNavigatorResources.INSTANCE.css().treeFolder() );
             folder.getElement().getStyle().setDisplay( Style.Display.BLOCK );
             {
-                this.header = new FlowPanel();
+                this.header = GWT.create( FlowPanel.class );
                 this.icon = new Icon( IconType.FOLDER );
                 this.content = new FlowPanel();
                 final Anchor name = new Anchor();
@@ -87,7 +88,6 @@ public class TreeItem extends Composite {
                         public void onClick( ClickEvent event ) {
                             if ( !isSelected ) {
                                 updateSelected();
-                                return;
                             }
                             if ( state.equals( State.CLOSE ) ) {
                                 setState( State.OPEN, true );
@@ -105,7 +105,7 @@ public class TreeItem extends Composite {
                 initWidget( folder );
             }
         } else if ( type.equals( Type.ITEM ) ) {
-            this.item = new FlowPanel();
+            this.item = GWT.create( FlowPanel.class );
             item.setStylePrimaryName( TreeNavigatorResources.INSTANCE.css().treeItem() );
             {
                 this.icon = new Icon( IconType.FILE_O );

--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/tree/TreeItemTest.java
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/tree/TreeItemTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.widgets.core.client.tree;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class TreeItemTest {
+
+    @GwtMock
+    FlowPanel container;
+
+    ClickHandler clickHandler;
+
+    @Test
+    public void testItemEvents() {
+        when( container.addDomHandler( any( ClickHandler.class ),
+                                       any( ClickEvent.getType().getClass() ) ) ).thenAnswer( new Answer() {
+            @Override
+            public Object answer( InvocationOnMock aInvocation ) throws Throwable {
+                clickHandler = (ClickHandler) aInvocation.getArguments()[ 0 ];
+                return null;
+            }
+        } );
+
+        final Tree tree = mock( Tree.class );
+        final TreeItem treeItem = new TreeItem( TreeItem.Type.ITEM,
+                                                "item" );
+        treeItem.setTree( tree );
+
+        //Check items are selected
+        clickHandler.onClick( new ClickEvent() {
+        } );
+
+        verify( tree,
+                times( 1 ) ).onSelection( eq( treeItem ),
+                                          eq( true ) );
+        verify( tree,
+                never() ).fireStateChanged( eq( treeItem ),
+                                            eq( TreeItem.State.OPEN ) );
+    }
+
+    @Test
+    public void testFolderEvents() {
+        when( container.addDomHandler( any( ClickHandler.class ),
+                                       any( ClickEvent.getType().getClass() ) ) ).thenAnswer( new Answer() {
+            @Override
+            public Object answer( InvocationOnMock aInvocation ) throws Throwable {
+                clickHandler = (ClickHandler) aInvocation.getArguments()[ 0 ];
+                return null;
+            }
+        } );
+
+        final Tree tree = mock( Tree.class );
+        final TreeItem treeItem = new TreeItem( TreeItem.Type.FOLDER,
+                                                "folder" );
+        treeItem.setTree( tree );
+
+        //Check folders are selected and opened
+        clickHandler.onClick( new ClickEvent() {
+        } );
+
+        verify( tree,
+                times( 1 ) ).onSelection( eq( treeItem ),
+                                          eq( true ) );
+        verify( tree,
+                times( 1 ) ).fireStateChanged( eq( treeItem ),
+                                               eq( TreeItem.State.OPEN ) );
+
+        //Check folders are closed when clicked again
+        clickHandler.onClick( new ClickEvent() {
+        } );
+
+        verify( tree,
+                times( 2 ) ).onSelection( eq( treeItem ),
+                                          eq( true ) );
+        verify( tree,
+                times( 1 ) ).fireStateChanged( eq( treeItem ),
+                                               eq( TreeItem.State.CLOSE ) );
+    }
+
+}


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1304659

Corollary of https://github.com/uberfire/uberfire-extensions/pull/214 for 0.8.x.

(cherry picked from commit 9d5acbd3a4c0c1a6e9fee88e551d6e3a2c1531a7)