### PR TITLE
GUVNOR-2414: When deleting a file from a project, an error message is shown even though the file is succesfully deleted.

### DIFF
--- a/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/CopyService.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/CopyService.java
@@ -15,10 +15,32 @@
  */
 package org.uberfire.ext.editor.commons.service;
 
+import java.util.Collection;
+
 import org.jboss.errai.bus.server.annotations.Remote;
+import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 
+/**
+ * Responsible for paths copy.
+ */
 @Remote
 public interface CopyService extends SupportsCopy {
 
+    /**
+     * Copies (in batch) the paths passed in {@param paths}, if they exist.
+     * @param paths Paths that will be removed.
+     * @param newName New path's name.
+     * @param comment Comment about the renaming.
+     */
+    void copyIfExists( final Collection<Path> paths,
+                       final String newName,
+                       final String comment );
+
+    /**
+     * Verifies if a path can be copied.
+     * @param path Path to be verified.
+     * @return true if there is a restriction and the path cannot be copied, and false otherwise.
+     */
+    boolean hasRestriction( Path path );
 }

--- a/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/DeleteService.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/DeleteService.java
@@ -15,11 +15,29 @@
  */
 package org.uberfire.ext.editor.commons.service;
 
+import java.util.Collection;
+
 import org.jboss.errai.bus.server.annotations.Remote;
+import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 
+/**
+ * Responsible for paths removal.
+ */
 @Remote
 public interface DeleteService extends SupportsDelete {
 
+    /**
+     * Deletes (in batch) the paths passed in {@param paths}, if they exist.
+     * @param paths Paths that will be removed.
+     */
+    void deleteIfExists( final Collection<Path> paths,
+                         final String comment );
 
+    /**
+     * Verifies if a path can be deleted.
+     * @param path Path to be verified.
+     * @return true if there is a restriction and the path cannot be deleted, and false otherwise.
+     */
+    boolean hasRestriction( Path path );
 }

--- a/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/RenameService.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/RenameService.java
@@ -15,10 +15,32 @@
  */
 package org.uberfire.ext.editor.commons.service;
 
+import java.util.Collection;
+
 import org.jboss.errai.bus.server.annotations.Remote;
+import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
 
+/**
+ * Responsible for paths renaming.
+ */
 @Remote
 public interface RenameService extends SupportsRename {
 
+    /**
+     * Renames (in batch) the paths passed in {@param paths}, if they exist.
+     * @param paths Paths that will be renamed.
+     * @param newName Path's new name.
+     * @param comment Comment about the renaming.
+     */
+    void renameIfExists( final Collection<Path> paths,
+                         final String newName,
+                         final String comment );
+
+    /**
+     * Verifies if a path can be renamed.
+     * @param path Path to be verified.
+     * @return true if there is a restriction and the path cannot be renamed, and false otherwise.
+     */
+    boolean hasRestriction( Path path );
 }

--- a/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restriction/PathOperationRestriction.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restriction/PathOperationRestriction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 JBoss, by Red Hat, Inc
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,19 @@
  * limitations under the License.
  */
 
-package org.uberfire.ext.editor.commons.service;
+package org.uberfire.ext.editor.commons.service.restriction;
 
-import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
 
 /**
- * This service is responsible for doing general validation on files and paths.
+ * Represents a restriction to a path operation (copy, delete or rename).
  */
-@Remote
-public interface ValidationService {
+public interface PathOperationRestriction {
 
     /**
-     * Checks if the path and file name is valid.
+     * Returns the message which describes the restriction.
+     * @param path Path related to the restriction.
+     * @return Message related to the restriction.
      */
-    boolean isFileNameValid( final Path path,
-                             final String fileName );
-
-    /**
-     * Checks if the file name is valid.
-     */
-    boolean isFileNameValid( final String fileName );
+    String getMessage( Path path );
 }

--- a/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restrictor/CopyRestrictor.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restrictor/CopyRestrictor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.service.restrictor;
+
+/**
+ * Represents a restrictor to a copy operation.
+ */
+public interface CopyRestrictor extends PathOperationRestrictor {
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restrictor/DeleteRestrictor.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restrictor/DeleteRestrictor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.service.restrictor;
+
+/**
+ * Represents a restrictor to a delete operation.
+ */
+public interface DeleteRestrictor extends PathOperationRestrictor {
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restrictor/PathOperationRestrictor.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restrictor/PathOperationRestrictor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 JBoss, by Red Hat, Inc
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,20 @@
  * limitations under the License.
  */
 
-package org.uberfire.ext.editor.commons.service;
+package org.uberfire.ext.editor.commons.service.restrictor;
 
-import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.service.restriction.PathOperationRestriction;
 
 /**
- * This service is responsible for doing general validation on files and paths.
+ * Represents a restrictor to a path operation (copy, delete or rename).
  */
-@Remote
-public interface ValidationService {
+public interface PathOperationRestrictor {
 
     /**
-     * Checks if the path and file name is valid.
+     * Checks if there is a restriction to execute a operation on this path.
+     * @param path Path to be checked.
+     * @return The restriction to execute the operation, or null if there is not one.
      */
-    boolean isFileNameValid( final Path path,
-                             final String fileName );
-
-    /**
-     * Checks if the file name is valid.
-     */
-    boolean isFileNameValid( final String fileName );
+    PathOperationRestriction hasRestriction( Path path );
 }

--- a/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restrictor/RenameRestrictor.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/restrictor/RenameRestrictor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.service.restrictor;
+
+/**
+ * Represents a restrictor to a rename operation.
+ */
+public interface RenameRestrictor extends PathOperationRestrictor {
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/service/DeleteServiceImpl.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/service/DeleteServiceImpl.java
@@ -16,7 +16,9 @@
 
 package org.uberfire.ext.editor.commons.backend.service;
 
+import java.util.Collection;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -26,11 +28,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.backend.vfs.VFSLockService;
-import org.uberfire.backend.vfs.impl.LockInfo;
 import org.uberfire.ext.editor.commons.service.DeleteService;
+import org.uberfire.ext.editor.commons.service.restriction.PathOperationRestriction;
+import org.uberfire.ext.editor.commons.service.restrictor.DeleteRestrictor;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.base.options.CommentedOption;
+import org.uberfire.java.nio.file.StandardDeleteOption;
 import org.uberfire.rpc.SessionInfo;
 
 @Service
@@ -48,9 +51,9 @@ public class DeleteServiceImpl implements DeleteService {
 
     @Inject
     private SessionInfo sessionInfo;
-    
+
     @Inject
-    private VFSLockService lockService;
+    private Instance<DeleteRestrictor> deleteRestrictorBeans;
 
     @Override
     public void delete( final Path path,
@@ -58,20 +61,90 @@ public class DeleteServiceImpl implements DeleteService {
         
         LOGGER.info( "User:" + identity.getIdentifier() + " deleting file [" + path.getFileName() + "]" );
 
-        final LockInfo lockInfo = lockService.retrieveLockInfo( path );
-        if ( lockInfo.isLocked() && !identity.getIdentifier().equals( lockInfo.lockedBy() ) ) {
-            throw new RuntimeException( path.toURI() + " cannot be deleted. It is locked by: " + lockInfo.lockedBy() );
-        }
+        checkRestrictions( path );
 
         try {
-            ioService.delete( Paths.convert( path ),
-                              new CommentedOption( sessionInfo != null ? sessionInfo.getId() : "--",
-                                                   identity.getIdentifier(),
-                                                   null,
-                                                   comment ) );
-            
+            deletePath( path, comment );
         } catch ( final Exception e ) {
             throw new RuntimeException( e );
         }
+    }
+
+    @Override
+    public void deleteIfExists( final Collection<Path> paths,
+                                final String comment ) {
+        try {
+            startBatch( paths );
+
+            for ( final Path path : paths ) {
+                LOGGER.info( "User:" + identity.getIdentifier() + " deleting file (if exists) [" + path.getFileName() + "]" );
+
+                checkRestrictions( path );
+                deletePathIfExists( path, comment );
+            }
+        } catch ( final RuntimeException e ) {
+            throw e;
+        } catch ( final Exception e ) {
+            throw new RuntimeException( e );
+        } finally {
+            endBatch( paths );
+        }
+    }
+
+    @Override
+    public boolean hasRestriction( final Path path ) {
+        for ( DeleteRestrictor deleteRestrictor : getDeleteRestrictors() ) {
+            final PathOperationRestriction deleteRestriction = deleteRestrictor.hasRestriction( path );
+            if ( deleteRestriction != null ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void checkRestrictions( final Path path ) {
+        for ( DeleteRestrictor deleteRestrictor : getDeleteRestrictors() ) {
+            final PathOperationRestriction deleteRestriction = deleteRestrictor.hasRestriction( path );
+            if ( deleteRestriction != null ) {
+                throw new RuntimeException( deleteRestriction.getMessage( path ) );
+            }
+        }
+    }
+
+    void deletePath( final Path path,
+                     final String comment ) {
+        ioService.delete( Paths.convert( path ),
+                          new CommentedOption( sessionInfo != null ? sessionInfo.getId() : "--",
+                                               identity.getIdentifier(),
+                                               null,
+                                               comment ) );
+    }
+
+    void deletePathIfExists( final Path path,
+                             final String comment ) {
+        ioService.deleteIfExists( Paths.convert( path ),
+                                  new CommentedOption( sessionInfo.getId(),
+                                                       identity.getIdentifier(),
+                                                       null,
+                                                       comment ),
+                                  StandardDeleteOption.NON_EMPTY_DIRECTORIES
+                                );
+    }
+
+    void startBatch( final Collection<Path> paths ) {
+        if ( paths.size() > 1 ) {
+            ioService.startBatch( Paths.convert( paths.iterator().next() ).getFileSystem() );
+        }
+    }
+
+    void endBatch( final Collection<Path> paths ) {
+        if ( paths.size() > 1 ) {
+            ioService.endBatch();
+        }
+    }
+
+    Iterable<DeleteRestrictor> getDeleteRestrictors() {
+        return deleteRestrictorBeans;
     }
 }

--- a/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/service/restriction/LockRestrictor.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/service/restriction/LockRestrictor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.backend.service.restriction;
+
+import java.util.List;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.VFSLockService;
+import org.uberfire.backend.vfs.impl.LockInfo;
+import org.uberfire.ext.editor.commons.service.restriction.PathOperationRestriction;
+import org.uberfire.ext.editor.commons.service.restrictor.DeleteRestrictor;
+import org.uberfire.ext.editor.commons.service.restrictor.RenameRestrictor;
+
+@ApplicationScoped
+public class LockRestrictor implements DeleteRestrictor,
+                                       RenameRestrictor {
+
+    @Inject
+    private VFSLockService lockService;
+
+    @Inject
+    private User identity;
+
+    @Override
+    public PathOperationRestriction hasRestriction( final Path path ) {
+        final LockInfo lockInfo = lockService.retrieveLockInfo( path );
+        if ( lockInfo != null && lockInfo.isLocked() && !identity.getIdentifier().equals( lockInfo.lockedBy() ) ) {
+            return new PathOperationRestriction() {
+                @Override
+                public String getMessage( final Path path ) {
+                    return path.toURI() + " cannot be deleted, moved or renamed. It is locked by: " + lockInfo.lockedBy();
+                }
+            };
+        }
+
+        final List<LockInfo> lockInfos = lockService.retrieveLockInfos( path, true );
+        if ( lockInfos != null && !lockInfos.isEmpty() ) {
+            return new PathOperationRestriction() {
+                @Override
+                public String getMessage( final Path path ) {
+                    return path.toURI() + " cannot be deleted, moved or renamed. It contains the following locked files: " + lockInfos;
+                }
+            };
+        }
+
+        return null;
+    }
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/CopyServiceImplTest.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/CopyServiceImplTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.backend.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.backend.vfs.VFSLockService;
+import org.uberfire.backend.vfs.impl.LockInfo;
+import org.uberfire.ext.editor.commons.backend.service.restriction.LockRestrictor;
+import org.uberfire.ext.editor.commons.service.ValidationService;
+import org.uberfire.ext.editor.commons.service.restriction.PathOperationRestriction;
+import org.uberfire.ext.editor.commons.service.restrictor.CopyRestrictor;
+import org.uberfire.io.IOService;
+import org.uberfire.rpc.SessionInfo;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CopyServiceImplTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private User identity;
+
+    @Mock
+    private SessionInfo sessionInfo;
+
+    @Mock
+    private VFSLockService lockService;
+
+    @Mock
+    private ValidationService validationService;
+
+    @Spy
+    @InjectMocks
+    private CopyServiceImpl copyService;
+
+    @Spy
+    @InjectMocks
+    private LockRestrictor lockRestrictor;
+
+    private final List<String> restrictedFileNames = new ArrayList<String>();
+
+    @Before
+    public void setup() {
+        when( identity.getIdentifier() ).thenReturn( "user" );
+
+        doReturn( getPath() ).when( copyService ).copyPath( any( Path.class ), any( String.class ), any( String.class ) );
+        doNothing().when( copyService ).copyPathIfExists( any( Path.class ), any( String.class ), any( String.class ) );
+        doNothing().when( copyService ).startBatch( Matchers.<Collection<Path>>any() );
+        doNothing().when( copyService ).endBatch();
+
+        List<CopyRestrictor> copyRestrictors = new ArrayList<CopyRestrictor>();
+        copyRestrictors.add( new CopyRestrictor() {
+            @Override
+            public PathOperationRestriction hasRestriction( final Path path ) {
+                if ( restrictedFileNames.contains( path.getFileName() ) ) {
+                    return new PathOperationRestriction() {
+                        @Override
+                        public String getMessage( final Path path ) {
+                            return path.toURI() + " cannot be copied.";
+                        }
+                    };
+                }
+
+                return null;
+            }
+        } );
+        when( copyService.getCopyRestrictors() ).thenReturn( copyRestrictors );
+    }
+
+    @Test
+    public void copyRestrictedPathTest() {
+        final Path path = getPath( "restricted-file.txt" );
+
+        givenThatPathIsRestricted( path );
+
+        try {
+            whenPathIsCopied( path );
+        } catch ( RuntimeException e ) {
+            thenPathWasNotCopied( path, e );
+        }
+
+        thenPathWasNotCopied( path );
+    }
+
+    @Test
+    public void copyUnrestrictedPathTest() {
+        final Path path = getPath();
+
+        givenThatPathIsUnrestricted( path );
+        whenPathIsCopied( path );
+        thenPathWasCopied( path );
+    }
+
+    @Test
+    public void copyRestrictedPathIfExistsTest() {
+        final List<Path> paths = new ArrayList<Path>();
+        paths.add( getPath( "file0.txt" ) );
+        paths.add( getPath( "file1.txt" ) );
+        paths.add( getPath( "file2.txt" ) );
+
+        givenThatPathIsUnrestricted( paths.get( 0 ) );
+        givenThatPathIsRestricted( paths.get( 1 ) );
+        givenThatPathIsUnrestricted( paths.get( 2 ) );
+
+        try {
+            whenPathsAreCopiedIfExists( paths );
+        } catch ( RuntimeException e ) {
+            thenPathWasNotCopiedIfExists( paths.get( 1 ), e );
+        }
+
+        thenPathWasCopiedIfExists( paths.get( 0 ) );
+        thenPathWasNotCopiedIfExists( paths.get( 1 ) );
+
+        // This will not be copied because the process stops when some exception is raised.
+        thenPathWasNotCopiedIfExists( paths.get( 2 ) );
+    }
+
+    @Test
+    public void copyUnrestrictedPathIfExistsTest() {
+        final List<Path> paths = new ArrayList<Path>();
+        paths.add( getPath( "file0.txt" ) );
+        paths.add( getPath( "file1.txt" ) );
+        paths.add( getPath( "file2.txt" ) );
+
+        givenThatPathIsUnrestricted( paths.get( 0 ) );
+        givenThatPathIsUnrestricted( paths.get( 1 ) );
+        givenThatPathIsUnrestricted( paths.get( 2 ) );
+
+        whenPathsAreCopiedIfExists( paths );
+
+        thenPathWasCopiedIfExists( paths.get( 0 ) );
+        thenPathWasCopiedIfExists( paths.get( 1 ) );
+        thenPathWasCopiedIfExists( paths.get( 2 ) );
+    }
+
+    @Test
+    public void pathHasNoCopyRestrictionTest() {
+        final Path path = getPath();
+
+        givenThatPathIsUnrestricted( path );
+        boolean hasRestriction = whenPathIsCheckedForCopyRestrictions( path );
+        thenPathHasNoCopyRestrictions( hasRestriction );
+    }
+
+    @Test
+    public void pathHasCopyRestrictionTest() {
+        final Path path = getPath();
+
+        givenThatPathIsRestricted( path );
+        boolean hasRestriction = whenPathIsCheckedForCopyRestrictions( path );
+        thenPathHasCopyRestrictions( hasRestriction );
+    }
+
+    private void givenThatPathIsRestricted( final Path path ) {
+        restrictedFileNames.add( path.getFileName() );
+    }
+
+    private void givenThatPathIsUnrestricted( final Path path ) {
+        restrictedFileNames.remove( path.getFileName() );
+    }
+
+    private void whenPathIsCopied( final Path path ) {
+        copyService.copy( path, "newName", "comment" );
+    }
+
+    private void whenPathsAreCopiedIfExists( final Collection<Path> paths ) {
+        copyService.copyIfExists( paths, "newName", "comment" );
+    }
+
+    private boolean whenPathIsCheckedForCopyRestrictions( final Path path ) {
+        return copyService.hasRestriction( path );
+    }
+
+    private void thenPathWasCopied( final Path path ) {
+        verify( copyService ).copyPath( eq( path ), any( String.class ), any( String.class ) );
+    }
+
+    private void thenPathWasNotCopied( final Path path ) {
+        verify( copyService, never() ).copyPath( eq( path ), any( String.class ), any( String.class ) );
+    }
+
+    private void thenPathWasNotCopied( final Path path,
+                                        final RuntimeException e ) {
+        assertEquals( path.toURI() + " cannot be copied.", e.getMessage() );
+    }
+
+    private void thenPathWasCopiedIfExists( final Path path ) {
+        verify( copyService ).copyPathIfExists( eq( path ), any( String.class ), any( String.class ) );
+    }
+
+    private void thenPathWasNotCopiedIfExists( final Path path ) {
+        verify( copyService, never() ).copyPathIfExists( eq( path ), any( String.class ), any( String.class ) );
+    }
+
+    private void thenPathWasNotCopiedIfExists( final Path path,
+                                                final RuntimeException e ) {
+        assertEquals( path.toURI() + " cannot be copied.", e.getMessage() );
+    }
+
+    private void thenPathHasNoCopyRestrictions( final boolean hasRestriction ) {
+        assertFalse( hasRestriction );
+    }
+
+    private void thenPathHasCopyRestrictions( final boolean hasRestriction ) {
+        assertTrue( hasRestriction );
+    }
+
+    private Path getPath() {
+        return getPath( "file.txt" );
+    }
+
+    private Path getPath( String fileName ) {
+        return PathFactory.newPath( fileName, "file://tmp/" + fileName );
+    }
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/DeleteServiceImplTest.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/DeleteServiceImplTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.backend.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.backend.vfs.VFSLockService;
+import org.uberfire.backend.vfs.impl.LockInfo;
+import org.uberfire.ext.editor.commons.backend.service.restriction.LockRestrictor;
+import org.uberfire.ext.editor.commons.service.ValidationService;
+import org.uberfire.ext.editor.commons.service.restrictor.DeleteRestrictor;
+import org.uberfire.io.IOService;
+import org.uberfire.rpc.SessionInfo;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeleteServiceImplTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private User identity;
+
+    @Mock
+    private SessionInfo sessionInfo;
+
+    @Mock
+    private VFSLockService lockService;
+
+    @Mock
+    private ValidationService validationService;
+
+    @Spy
+    @InjectMocks
+    private DeleteServiceImpl deleteService;
+
+    @Spy
+    @InjectMocks
+    private LockRestrictor lockRestrictor;
+
+    @Before
+    public void setup() {
+        when( identity.getIdentifier() ).thenReturn( "user" );
+
+        doNothing().when( deleteService ).deletePath( any( Path.class ), any( String.class ) );
+        doNothing().when( deleteService ).deletePathIfExists( any( Path.class ), any( String.class ) );
+        doNothing().when( deleteService ).startBatch( Matchers.<Collection<Path>>any() );
+        doNothing().when( deleteService ).endBatch( Matchers.<Collection<Path>>any() );
+
+        List<DeleteRestrictor> deleteRestrictors = new ArrayList<DeleteRestrictor>();
+        deleteRestrictors.add( lockRestrictor );
+        when( deleteService.getDeleteRestrictors() ).thenReturn( deleteRestrictors );
+    }
+
+    @Test
+    public void deleteLockedPathTest() {
+        final Path path = getPath();
+
+        givenThatPathIsLocked( path );
+
+        try {
+            whenPathIsDeleted( path );
+        } catch ( RuntimeException e ) {
+            thenPathWasNotDeleted( path, e );
+        }
+
+        thenPathWasNotDeleted( path );
+    }
+
+    @Test
+    public void deleteUnlockedPathTest() {
+        final Path path = getPath();
+
+        givenThatPathIsUnlocked( path );
+        whenPathIsDeleted( path );
+        thenPathWasDeleted( path );
+    }
+
+    @Test
+    public void deleteLockedPathIfExistsTest() {
+        final List<Path> paths = new ArrayList<Path>();
+        paths.add( getPath( "file0.txt" ) );
+        paths.add( getPath( "file1.txt" ) );
+        paths.add( getPath( "file2.txt" ) );
+
+        givenThatPathIsUnlocked( paths.get( 0 ) );
+        givenThatPathIsLocked( paths.get( 1 ) );
+        givenThatPathIsUnlocked( paths.get( 2 ) );
+
+        try {
+            whenPathsAreDeletedIfExists( paths );
+        } catch ( RuntimeException e ) {
+            thenPathWasNotDeletedIfExists( paths.get( 1 ), e );
+        }
+
+        thenPathWasDeletedIfExists( paths.get( 0 ) );
+        thenPathWasNotDeletedIfExists( paths.get( 1 ) );
+
+        // This will not be deleted because the process stops when some exception is raised.
+        thenPathWasNotDeletedIfExists( paths.get( 2 ) );
+    }
+
+    @Test
+    public void deleteUnlockedPathIfExistsTest() {
+        final List<Path> paths = new ArrayList<Path>();
+        paths.add( getPath( "file0.txt" ) );
+        paths.add( getPath( "file1.txt" ) );
+        paths.add( getPath( "file2.txt" ) );
+
+        givenThatPathIsUnlocked( paths.get( 0 ) );
+        givenThatPathIsUnlocked( paths.get( 1 ) );
+        givenThatPathIsUnlocked( paths.get( 2 ) );
+
+        whenPathsAreDeletedIfExists( paths );
+
+        thenPathWasDeletedIfExists( paths.get( 0 ) );
+        thenPathWasDeletedIfExists( paths.get( 1 ) );
+        thenPathWasDeletedIfExists( paths.get( 2 ) );
+    }
+
+    @Test
+    public void pathHasNoDeleteRestrictionTest() {
+        final Path path = getPath();
+
+        givenThatPathIsUnlocked( path );
+        boolean hasRestriction = whenPathIsCheckedForDeleteRestrictions( path );
+        thenPathHasNoDeleteRestrictions( hasRestriction );
+    }
+
+    @Test
+    public void pathHasDeleteRestrictionTest() {
+        final Path path = getPath();
+
+        givenThatPathIsLocked( path );
+        boolean hasRestriction = whenPathIsCheckedForDeleteRestrictions( path );
+        thenPathHasDeleteRestrictions( hasRestriction );
+    }
+
+    private void givenThatPathIsLocked( final Path path ) {
+        changeLockInfo( path, true );
+    }
+
+    private void givenThatPathIsUnlocked( final Path path ) {
+        changeLockInfo( path, false );
+    }
+
+    private void whenPathIsDeleted( final Path path ) {
+        deleteService.delete( path, "comment" );
+    }
+
+    private void whenPathsAreDeletedIfExists( final Collection<Path> paths ) {
+        deleteService.deleteIfExists( paths, "comment" );
+    }
+
+    private boolean whenPathIsCheckedForDeleteRestrictions( final Path path ) {
+        return deleteService.hasRestriction( path );
+    }
+
+    private void thenPathWasDeleted( final Path path ) {
+        verify( deleteService ).deletePath( eq( path ), any( String.class ) );
+    }
+
+    private void thenPathWasNotDeleted( final Path path ) {
+        verify( deleteService, never() ).deletePath( eq( path ), any( String.class ) );
+    }
+
+    private void thenPathWasNotDeleted( final Path path,
+                                        final RuntimeException e ) {
+        assertEquals( path.toURI() + " cannot be deleted, moved or renamed. It is locked by: lockedBy", e.getMessage() );
+    }
+
+    private void thenPathWasDeletedIfExists( final Path path ) {
+        verify( deleteService ).deletePathIfExists( eq( path ), any( String.class ) );
+    }
+
+    private void thenPathWasNotDeletedIfExists( final Path path ) {
+        verify( deleteService, never() ).deletePathIfExists( eq( path ), any( String.class ) );
+    }
+
+    private void thenPathWasNotDeletedIfExists( final Path path,
+                                                final RuntimeException e ) {
+        assertEquals( path.toURI() + " cannot be deleted, moved or renamed. It is locked by: lockedBy", e.getMessage() );
+    }
+
+    private void thenPathHasNoDeleteRestrictions( final boolean hasRestriction ) {
+        assertFalse( hasRestriction );
+    }
+
+    private void thenPathHasDeleteRestrictions( final boolean hasRestriction ) {
+        assertTrue( hasRestriction );
+    }
+
+    private Path getPath() {
+        return getPath( "file.txt" );
+    }
+
+    private Path getPath( String fileName ) {
+        return PathFactory.newPath( fileName, "file://tmp/" + fileName );
+    }
+
+    private void changeLockInfo( Path path,
+                                 boolean locked ) {
+        when( lockService.retrieveLockInfo( path ) ).thenReturn( new LockInfo( locked, "lockedBy", path ) );
+    }
+}

--- a/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/RenameServiceImplTest.java
+++ b/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/RenameServiceImplTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.backend.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.backend.vfs.VFSLockService;
+import org.uberfire.backend.vfs.impl.LockInfo;
+import org.uberfire.ext.editor.commons.backend.service.restriction.LockRestrictor;
+import org.uberfire.ext.editor.commons.service.ValidationService;
+import org.uberfire.ext.editor.commons.service.restrictor.RenameRestrictor;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.rpc.SessionInfo;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RenameServiceImplTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private User identity;
+
+    @Mock
+    private SessionInfo sessionInfo;
+
+    @Mock
+    private VFSLockService lockService;
+
+    @Mock
+    private ValidationService validationService;
+
+    @Spy
+    @InjectMocks
+    private RenameServiceImpl renameService;
+
+    @Spy
+    @InjectMocks
+    private LockRestrictor lockRestrictor;
+
+    @Before
+    public void setup() throws Exception {
+        when( identity.getIdentifier() ).thenReturn( "user" );
+
+        doReturn( getPath() ).when( renameService ).renamePath( any( Path.class ), any( String.class ), any( String.class ) );
+        doNothing().when( renameService ).renamePathIfExists( any( Path.class ), any( String.class ), any( String.class ) );
+        doNothing().when( renameService ).startBatch( Matchers.<Collection<Path>>any() );
+        doNothing().when( renameService ).endBatch();
+
+        List<RenameRestrictor> renameRestrictors = new ArrayList<RenameRestrictor>();
+        renameRestrictors.add( lockRestrictor );
+        when( renameService.getRenameRestrictors() ).thenReturn( renameRestrictors );
+    }
+
+    @Test
+    public void renameLockedPathTest() {
+        final Path path = getPath();
+
+        givenThatPathIsLocked( path );
+
+        try {
+            whenPathIsRenamed( path );
+        } catch ( RuntimeException e ) {
+            thenPathWasNotRenamed( path, e );
+        }
+
+        thenPathWasNotRenamed( path );
+    }
+
+    @Test
+    public void renameUnlockedPathTest() {
+        final Path path = getPath();
+
+        givenThatPathIsUnlocked( path );
+        whenPathIsRenamed( path );
+        thenPathWasRenamed( path );
+    }
+
+    @Test
+    public void renameLockedPathIfExistsTest() {
+        final List<Path> paths = new ArrayList<Path>();
+        paths.add( getPath( "file0.txt" ) );
+        paths.add( getPath( "file1.txt" ) );
+        paths.add( getPath( "file2.txt" ) );
+
+        givenThatPathIsUnlocked( paths.get( 0 ) );
+        givenThatPathIsLocked( paths.get( 1 ) );
+        givenThatPathIsUnlocked( paths.get( 2 ) );
+
+        try {
+            whenPathsAreRenamedIfExists( paths );
+        } catch ( RuntimeException e ) {
+            thenPathWasNotRenamedIfExists( paths.get( 1 ), e );
+        }
+
+        thenPathWasRenamedIfExists( paths.get( 0 ) );
+        thenPathWasNotRenamedIfExists( paths.get( 1 ) );
+
+        // This will not be renamed because the process stops when some exception is raised.
+        thenPathWasNotRenamedIfExists( paths.get( 2 ) );
+    }
+
+    @Test
+    public void renameUnlockedPathIfExistsTest() {
+        final List<Path> paths = new ArrayList<Path>();
+        paths.add( getPath( "file0.txt" ) );
+        paths.add( getPath( "file1.txt" ) );
+        paths.add( getPath( "file2.txt" ) );
+
+        givenThatPathIsUnlocked( paths.get( 0 ) );
+        givenThatPathIsUnlocked( paths.get( 1 ) );
+        givenThatPathIsUnlocked( paths.get( 2 ) );
+
+        whenPathsAreRenamedIfExists( paths );
+
+        thenPathWasRenamedIfExists( paths.get( 0 ) );
+        thenPathWasRenamedIfExists( paths.get( 1 ) );
+        thenPathWasRenamedIfExists( paths.get( 2 ) );
+    }
+
+    @Test
+    public void pathHasNoRenameRestrictionTest() {
+        final Path path = getPath();
+
+        givenThatPathIsUnlocked( path );
+        boolean hasRestriction = whenPathIsCheckedForRenameRestrictions( path );
+        thenPathHasNoRenameRestrictions( hasRestriction );
+    }
+
+    @Test
+    public void pathHasRenameRestrictionTest() {
+        final Path path = getPath();
+
+        givenThatPathIsLocked( path );
+        boolean hasRestriction = whenPathIsCheckedForRenameRestrictions( path );
+        thenPathHasRenameRestrictions( hasRestriction );
+    }
+
+    private void givenThatPathIsLocked( final Path path ) {
+        changeLockInfo( path, true );
+    }
+
+    private void givenThatPathIsUnlocked( final Path path ) {
+        changeLockInfo( path, false );
+    }
+
+    private void whenPathIsRenamed( final Path path ) {
+        renameService.rename( path, "newname", "comment" );
+    }
+
+    private void whenPathsAreRenamedIfExists( final Collection<Path> paths ) {
+        renameService.renameIfExists( paths, "newname", "comment" );
+    }
+
+    private boolean whenPathIsCheckedForRenameRestrictions( final Path path ) {
+        return renameService.hasRestriction( path );
+    }
+
+    private void thenPathWasRenamed( final Path path ) {
+        verify( renameService ).renamePath( eq( path ), any( String.class ), any( String.class ) );
+    }
+
+    private void thenPathWasNotRenamed( final Path path ) {
+        verify( renameService, never() ).renamePath( eq( path ), any( String.class ), any( String.class ) );
+    }
+
+    private void thenPathWasNotRenamed( final Path path,
+                                        final RuntimeException e ) {
+        assertEquals( path.toURI() + " cannot be deleted, moved or renamed. It is locked by: lockedBy", e.getMessage() );
+    }
+
+    private void thenPathWasRenamedIfExists( final Path path ) {
+        verify( renameService ).renamePathIfExists( eq( path ), any( String.class ), any( String.class ) );
+    }
+
+    private void thenPathWasNotRenamedIfExists( final Path path ) {
+        verify( renameService, never() ).renamePathIfExists( eq( path ), any( String.class ), any( String.class ) );
+    }
+
+    private void thenPathWasNotRenamedIfExists( final Path path,
+                                                final RuntimeException e ) {
+        assertEquals( path.toURI() + " cannot be deleted, moved or renamed. It is locked by: lockedBy", e.getMessage() );
+    }
+
+    private void thenPathHasNoRenameRestrictions( final boolean hasRestriction ) {
+        assertFalse( hasRestriction );
+    }
+
+    private void thenPathHasRenameRestrictions( final boolean hasRestriction ) {
+        assertTrue( hasRestriction );
+    }
+
+    private Path getPath() {
+        return getPath( "file.txt" );
+    }
+
+    private Path getPath( String fileName ) {
+        return PathFactory.newPath( fileName, "file://tmp/" + fileName );
+    }
+
+    private void changeLockInfo( Path path,
+                                 boolean locked ) {
+        when( lockService.retrieveLockInfo( path ) ).thenReturn( new LockInfo( locked, "lockedBy", path ) );
+    }
+}


### PR DESCRIPTION
This PR adds (for uberfire-extensions' users) the capability to implement restrictors to delete, rename and copy services. 

The code added on deleteIfExists, renameIfExists and copyIfExists methods (in their respective services) were migrated from kie-wb-common.