### PR TITLE
Update SyncBeanDef implementations to upstream API change.

### DIFF
--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/generator/PerspectiveEditorGenerator.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/generator/PerspectiveEditorGenerator.java
@@ -125,7 +125,6 @@ public class PerspectiveEditorGenerator {
                                                                                                         PerspectiveActivity.class,
                                                                                                         new HashSet<Annotation>( Arrays.asList( DEFAULT_QUALIFIERS ) ),
                                                                                                         perspective.getName(),
-                                                                                                        true,
                                                                                                         true ) );
 
         activityBeansCache.addNewPerspectiveActivity( beanManager.lookupBeans( perspective.getName() ).iterator().next() );
@@ -143,7 +142,8 @@ public class PerspectiveEditorGenerator {
                         qualifiers,
                         activity.getIdentifier(),
                         true,
-                        true );
+                        WorkbenchScreenActivity.class,
+                        Activity.class );
 
         beanManager.registerBean( beanDef );
         beanManager.registerBeanTypeAlias( beanDef, Activity.class );


### PR DESCRIPTION
This PR should stay open until @psiroky is able to add Errai to the Jenkins job that tests PRs.

This updates usage of the SyncBeanDef interface updated in [this PR](https://github.com/errai/errai/pull/161). At present the Jenkins job that builds this PR will fail because it does not build the changes from the Errai PR.