### PR TITLE
BZ1303534: [GSS](6.2.z) BxMS6.2.0 Full Text search returns only 10 results even if it hits more than 10

### DIFF
--- a/uberfire-metadata/uberfire-metadata-api/pom.xml
+++ b/uberfire-metadata/uberfire-metadata-api/pom.xml
@@ -37,6 +37,11 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-io</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/search/IOSearchService.java
+++ b/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/search/IOSearchService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss, by Red Hat, Inc
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,24 +20,36 @@ import java.util.List;
 import java.util.Map;
 
 import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.java.nio.file.Path;
 
-/**
- *
- */
-public interface SearchIndex {
+public interface IOSearchService {
 
-    List<KObject> searchByAttrs( final Map<String, ?> attrs,
-                                 final IOSearchService.Filter filter,
-                                 final ClusterSegment... clusterSegments );
+    List<Path> searchByAttrs( final Map<String, ?> attrs,
+                              final Filter filter,
+                              final Path... roots );
 
-    List<KObject> fullTextSearch( final String term,
-                                  final IOSearchService.Filter filter,
-                                  final ClusterSegment... clusterSegments );
+    List<Path> fullTextSearch( final String term,
+                               final Filter filter,
+                               final Path... roots );
 
     int searchByAttrsHits( final Map<String, ?> attrs,
-                           final ClusterSegment... clusterSegments );
+                           final Path... roots );
 
     int fullTextSearchHits( final String term,
-                            final ClusterSegment... clusterSegments );
+                            final Path... roots );
+
+    interface Filter {
+
+        boolean accept( final KObject kObject );
+
+    }
+
+    class NoOpFilter implements Filter {
+
+        @Override
+        public boolean accept( final KObject kObject ) {
+            return true;
+        }
+    }
 
 }

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOSearchServiceImpl.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOSearchServiceImpl.java
@@ -18,40 +18,42 @@ package org.uberfire.ext.metadata.io;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.uberfire.io.IOSearchService;
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.ext.metadata.search.ClusterSegment;
+import org.uberfire.ext.metadata.search.IOSearchService;
+import org.uberfire.ext.metadata.search.SearchIndex;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.base.SegmentedPath;
 import org.uberfire.java.nio.file.Path;
-import org.uberfire.ext.metadata.model.KObject;
-import org.uberfire.ext.metadata.search.ClusterSegment;
-import org.uberfire.ext.metadata.search.SearchIndex;
 
 import static org.uberfire.commons.validation.PortablePreconditions.*;
 
 /**
  *
  */
-public class IOSearchIndex implements IOSearchService {
+public class IOSearchServiceImpl implements IOSearchService {
 
     private final SearchIndex searchIndex;
-    private final IOService   ioService;
+    private final IOService ioService;
 
-    public IOSearchIndex( final SearchIndex searchIndex,
-                          final IOService ioService ) {
+    public IOSearchServiceImpl( final SearchIndex searchIndex,
+                                final IOService ioService ) {
         this.searchIndex = checkNotNull( "searchIndex", searchIndex );
         this.ioService = checkNotNull( "ioService", ioService );
     }
 
     @Override
     public List<Path> searchByAttrs( final Map<String, ?> attrs,
-                                     final int pageSize,
-                                     final int startIndex,
+                                     final Filter filter,
                                      final Path... roots ) {
-        final List<KObject> kObjects = searchIndex.searchByAttrs( attrs, pageSize, startIndex, buildClusterSegments( roots ) );
+        final List<KObject> kObjects = searchIndex.searchByAttrs( attrs,
+                                                                  filter,
+                                                                  buildClusterSegments( roots ) );
         return new ArrayList<Path>() {{
             for ( KObject kObject : kObjects ) {
                 add( ioService.get( URI.create( kObject.getKey() ) ) );
@@ -61,10 +63,11 @@ public class IOSearchIndex implements IOSearchService {
 
     @Override
     public List<Path> fullTextSearch( final String term,
-                                      final int pageSize,
-                                      final int startIndex,
+                                      final Filter filter,
                                       final Path... roots ) {
-        final List<KObject> kObjects = searchIndex.fullTextSearch( term, pageSize, startIndex, buildClusterSegments( roots ) );
+        final List<KObject> kObjects = searchIndex.fullTextSearch( term,
+                                                                   filter,
+                                                                   buildClusterSegments( roots ) );
         return new ArrayList<Path>() {{
             for ( KObject kObject : kObjects ) {
                 add( ioService.get( URI.create( kObject.getKey() ) ) );
@@ -75,13 +78,15 @@ public class IOSearchIndex implements IOSearchService {
     @Override
     public int searchByAttrsHits( final Map<String, ?> attrs,
                                   final Path... roots ) {
-        return searchIndex.searchByAttrsHits( attrs, buildClusterSegments( roots ) );
+        return searchIndex.searchByAttrsHits( attrs,
+                                              buildClusterSegments( roots ) );
     }
 
     @Override
     public int fullTextSearchHits( final String term,
                                    final Path... roots ) {
-        return searchIndex.fullTextSearchHits( term, buildClusterSegments( roots ) );
+        return searchIndex.fullTextSearchHits( term,
+                                               buildClusterSegments( roots ) );
     }
 
     private ClusterSegment[] buildClusterSegments( final Path[] roots ) {

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneSearchIndexTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/LuceneSearchIndexTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.uberfire.ext.metadata.model.KObject;
 import org.uberfire.ext.metadata.search.ClusterSegment;
+import org.uberfire.ext.metadata.search.IOSearchService;
 import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.base.SegmentedPath;
 import org.uberfire.java.nio.file.Path;
@@ -82,8 +83,7 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
         {
             final int hits = config.getSearchIndex().searchByAttrsHits( attributes );
             final List<KObject> results = config.getSearchIndex().searchByAttrs( attributes,
-                                                                                 10,
-                                                                                 0 );
+                                                                                 new IOSearchService.NoOpFilter() );
             assertEquals( 0,
                           hits );
             assertEquals( 0,
@@ -94,8 +94,7 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
             final int hits = config.getSearchIndex().searchByAttrsHits( attributes,
                                                                         cs1 );
             final List<KObject> results = config.getSearchIndex().searchByAttrs( attributes,
-                                                                                 10,
-                                                                                 0,
+                                                                                 new IOSearchService.NoOpFilter(),
                                                                                  cs1 );
             assertEquals( 1,
                           hits );
@@ -107,8 +106,7 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
             final int hits = config.getSearchIndex().searchByAttrsHits( attributes,
                                                                         cs2 );
             final List<KObject> results = config.getSearchIndex().searchByAttrs( attributes,
-                                                                                 10,
-                                                                                 0,
+                                                                                 new IOSearchService.NoOpFilter(),
                                                                                  cs2 );
             assertEquals( 1,
                           hits );
@@ -121,8 +119,7 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
                                                                         cs1,
                                                                         cs2 );
             final List<KObject> results = config.getSearchIndex().searchByAttrs( attributes,
-                                                                                 10,
-                                                                                 0,
+                                                                                 new IOSearchService.NoOpFilter(),
                                                                                  cs1,
                                                                                  cs2 );
             assertEquals( 2,
@@ -135,8 +132,7 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
         {
             final int hits = config.getSearchIndex().fullTextSearchHits( "*indexed*" );
             final List<KObject> results = config.getSearchIndex().fullTextSearch( "*indexed*",
-                                                                                  10,
-                                                                                  0 );
+                                                                                  new IOSearchService.NoOpFilter() );
             assertEquals( 0,
                           hits );
             assertEquals( 0,
@@ -147,8 +143,7 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
             final int hits = config.getSearchIndex().fullTextSearchHits( "*indexed*",
                                                                          cs1 );
             final List<KObject> results = config.getSearchIndex().fullTextSearch( "*indexed*",
-                                                                                  10,
-                                                                                  0,
+                                                                                  new IOSearchService.NoOpFilter(),
                                                                                   cs1 );
             assertEquals( 1,
                           hits );
@@ -160,8 +155,7 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
             final int hits = config.getSearchIndex().fullTextSearchHits( "*indexed*",
                                                                          cs2 );
             final List<KObject> results = config.getSearchIndex().fullTextSearch( "*indexed*",
-                                                                                  10,
-                                                                                  0,
+                                                                                  new IOSearchService.NoOpFilter(),
                                                                                   cs2 );
             assertEquals( 1,
                           hits );
@@ -174,8 +168,7 @@ public class LuceneSearchIndexTest extends BaseIndexTest {
                                                                          cs1,
                                                                          cs2 );
             final List<KObject> results = config.getSearchIndex().fullTextSearch( "*indexed*",
-                                                                                  10,
-                                                                                  0,
+                                                                                  new IOSearchService.NoOpFilter(),
                                                                                   cs1,
                                                                                   cs2 );
             assertEquals( 2,


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1303534

This is the corollary of https://github.com/uberfire/uberfire-extensions/pull/230 for 0.7.x