### PR TITLE
[0.8.x] GUVNOR-2362: Project Explorer freezes after uploading an item with an extension-free name

### DIFF
--- a/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadBase.java
+++ b/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadBase.java
@@ -144,6 +144,10 @@ public abstract class DefaultEditorFileUploadBase
         fileUpload.upload();
     }
 
+    public String getFormFileName() {
+        return fileUpload.getFilename();
+    }
+
     private void executeCallback( final Command callback ) {
         if ( callback == null ) {
             return;


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2362

This is the corollary of https://github.com/uberfire/uberfire-extensions/pull/236 for 0.8.x

(cherry picked from commit 80d5fa80085c4b4b550038211c7eea458669c2fd)

Branch name is consistent across Uberfire and KIE to help Jenkins CI.

