### PR TITLE
Fix injection point in BasicAuthSecurityFilter for tomcat7

### DIFF
--- a/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/BasicAuthSecurityFilter.java
+++ b/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/BasicAuthSecurityFilter.java
@@ -38,18 +38,10 @@ public class BasicAuthSecurityFilter implements Filter {
 
     public static final String REALM_NAME_PARAM = "realmName";
 
-    private AuthenticationService authenticationService;
+    @Inject
+    AuthenticationService authenticationService;
 
     private String realmName = "UberFire Security Extension Default Realm";
-
-    public BasicAuthSecurityFilter() {
-        // for proxy only
-    }
-
-    @Inject
-    public BasicAuthSecurityFilter(AuthenticationService authenticationService) {
-        this.authenticationService = authenticationService;
-    }
 
     @Override
     public void init( FilterConfig filterConfig ) throws ServletException {

--- a/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/BasicAuthSecurityFilterTest.java
+++ b/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/BasicAuthSecurityFilterTest.java
@@ -67,7 +67,8 @@ public class BasicAuthSecurityFilterTest {
             }
         });
 
-        final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter(authenticationService);
+        final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter();
+        filter.authenticationService = authenticationService;
         filter.doFilter(request, response, chain);
 
         verify(httpSession, times(1)).invalidate();
@@ -86,7 +87,8 @@ public class BasicAuthSecurityFilterTest {
             }
         });
 
-        final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter(authenticationService);
+        final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter();
+        filter.authenticationService = authenticationService;
         filter.doFilter(request, response, chain);
 
         verify(httpSession, never()).invalidate();


### PR DESCRIPTION
PR for 0.8.x:

@mswiderski @ederign recent change/refactoring switched to constructor injection in this filter which doesn't work on tomcat7. so, this is switching back to field injection.