### PR TITLE
Move DataGrid to uf-widgets-table in order to remove dependency on uf…

### DIFF
--- a/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/SimpleTableTest.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/SimpleTableTest.java
@@ -9,7 +9,7 @@ import org.gwtbootstrap3.client.ui.Label;
 import org.gwtbootstrap3.client.ui.html.Text;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.uberfire.client.views.pfly.widgets.DataGrid;
+import org.uberfire.ext.widgets.table.client.DataGrid;
 
 import static org.mockito.Mockito.*;
 

--- a/uberfire-widgets/uberfire-widgets-table/pom.xml
+++ b/uberfire-widgets/uberfire-widgets-table/pom.xml
@@ -42,8 +42,12 @@
       <artifactId>gwtbootstrap3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
+      <artifactId>uberfire-commons</artifactId>
     </dependency>
   </dependencies>
 

--- a/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/DataGrid.java
+++ b/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/DataGrid.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.widgets.table.client;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.view.client.ProvidesKey;
+
+public class DataGrid<T> extends org.gwtbootstrap3.client.ui.gwt.DataGrid<T> {
+
+    public DataGrid(){
+        super();
+        setupDefaults();
+    }
+
+    public DataGrid(final ProvidesKey<T> keyProvider) {
+        super( keyProvider );
+        setupDefaults();
+    }
+
+    protected void setupDefaults(){
+        setHover( true );
+        setStriped( true );
+        setBordered( true );
+    }
+
+    @Override
+    protected void onLoad() {
+        super.onLoad();
+        fixTableStyle( this.getElement() );
+    }
+
+    public native void fixTableStyle( final Element e ) /*-{
+        var table = $wnd.jQuery(e).find( "table" ).first();
+        table.addClass( "table" );
+        table.css( "margin-bottom", "0px" );
+    }-*/;
+
+
+}

--- a/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/UberfireSimpleTable.java
+++ b/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/UberfireSimpleTable.java
@@ -15,6 +15,12 @@
  */
 package org.uberfire.ext.widgets.table.client;
 
+import java.util.List;
+
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.Label;
+import org.uberfire.ext.widgets.table.client.resources.UFTableResources;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Style;
@@ -25,14 +31,19 @@ import com.google.gwt.user.cellview.client.Column;
 import com.google.gwt.user.cellview.client.ColumnSortEvent;
 import com.google.gwt.user.cellview.client.ColumnSortList;
 import com.google.gwt.user.cellview.client.RowStyles;
-import com.google.gwt.user.client.ui.*;
-import com.google.gwt.view.client.*;
-import org.gwtbootstrap3.client.ui.Button;
-import org.gwtbootstrap3.client.ui.Label;
-import org.uberfire.client.views.pfly.widgets.DataGrid;
-import org.uberfire.ext.widgets.table.client.resources.UFTableResources;
-
-import java.util.List;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.HasWidgets;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.view.client.CellPreviewEvent;
+import com.google.gwt.view.client.HasData;
+import com.google.gwt.view.client.ProvidesKey;
+import com.google.gwt.view.client.Range;
+import com.google.gwt.view.client.RangeChangeEvent;
+import com.google.gwt.view.client.RowCountChangeEvent;
+import com.google.gwt.view.client.SelectionModel;
 
 /**
  * A composite Widget that shows rows of data (not-paged) and a "column picker"


### PR DESCRIPTION
…-wb-client-views-patternfly.

This change makes it possible to use the uf table widget without transitively depending
on ubefire-workbench-client.