### PR TITLE
Move CheckboxCellImpl to uberfire-widgets-table.

### DIFF
--- a/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/CheckboxCellImpl.java
+++ b/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/CheckboxCellImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.uberfire.ext.widgets.common.client.common;
+package org.uberfire.ext.widgets.table.client;
 
 import com.google.gwt.cell.client.AbstractEditableCell;
 import com.google.gwt.cell.client.Cell;


### PR DESCRIPTION
@ederign @csadilek This PR is also for the benefit of LiveSpark, which uses the CheckboxCellImpl to display boolean properties in generated apps.