### PR TITLE
- test showing issue with freeing the (lucene) lock on a repository

### DIFF
--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/pom.xml
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/pom.xml
@@ -70,6 +70,7 @@
       <artifactId>commons-io</artifactId>
     </dependency>
 
+    <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -78,6 +79,22 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-fs</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-jgit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-metadata-commons-io</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexEngineTest.java
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexEngineTest.java
@@ -16,26 +16,272 @@
 
 package org.uberfire.ext.metadata.backend.lucene.index;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.uberfire.commons.lifecycle.PriorityDisposableRegistry;
 import org.uberfire.ext.metadata.backend.lucene.LuceneConfig;
+import org.uberfire.ext.metadata.backend.lucene.LuceneConfigBuilder;
 import org.uberfire.ext.metadata.backend.lucene.fields.FieldFactory;
+import org.uberfire.ext.metadata.engine.Indexer;
 import org.uberfire.ext.metadata.engine.MetaModelStore;
-
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import org.uberfire.ext.metadata.io.IOServiceIndexedImpl;
+import org.uberfire.ext.metadata.io.IndexersFactory;
+import org.uberfire.ext.metadata.io.KObjectUtil;
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.ext.metadata.model.KObjectKey;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.attribute.FileAttribute;
 
 public class LuceneIndexEngineTest {
 
-    @Test
-    public void testDisposableRegistry() {
-        final LuceneConfig config = new LuceneConfig( mock( MetaModelStore.class ),
-                                                      mock( FieldFactory.class ),
-                                                      mock( LuceneIndexFactory.class ),
-                                                      mock( Analyzer.class ) );
+    protected IOService ioService;
+    private LuceneConfig config;
+    private CountDownLatch indexerCountDownLatch;
 
-        assertTrue( PriorityDisposableRegistry.getDisposables().contains( config ) );
+    protected Path basePath;
+    protected static final List<File> tempFiles = new ArrayList<File>();
+
+    @Before
+    public void setup() throws IOException {
+        final String repositoryName = getRepositoryName();
+        final String path = createTempDirectory().getAbsolutePath();
+        System.setProperty("org.uberfire.nio.git.dir", path);
+        System.setProperty("org.uberfire.nio.git.daemon.enabled", "false");
+        System.setProperty("org.uberfire.nio.git.ssh.enabled", "false");
+        System.setProperty("org.uberfire.sys.repo.monitor.disabled", "true");
+
+        final URI newRepo = URI.create("git://" + repositoryName);
+
+        try {
+            IOService ioService = ioService();
+
+            ioService.newFileSystem(newRepo, new HashMap<String, Object>());
+
+            basePath = getDirectoryPath().resolveSibling("someNewOtherPath");
+            ioService().write(basePath.resolve("dummy"), "<none>");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Unable to complete setup: " + e.getMessage());
+        }
     }
 
+    @AfterClass
+    @BeforeClass
+    public static void cleanup() {
+        for (final File tempFile : tempFiles) {
+            FileUtils.deleteQuietly(tempFile);
+        }
+    }
+
+    @Test
+    public void testIoServiceClose() throws IOException, InterruptedException {
+
+        String [] testFiles = new String [] { "one.txt", "two.txt" };
+
+        for( int i = 0; i < testFiles.length; ++i ) {
+            final Path path1 = basePath.resolve( testFiles[i] );
+            final String drl1 = loadText( testFiles[i] );
+            ioService().write( path1, drl1 );
+        }
+
+        // wait for indexing
+        indexerCountDownLatch.await();
+
+        // dispose of the IOService
+        ioService().dispose();
+
+        this.ioService = null;
+
+        // Set to "true" to fix problem
+        boolean undoLock = false;
+        if( undoLock ) {
+            config.dispose();
+        }
+        /**
+         *  and reinitialize IOService..
+         *
+         * (BOOM! Lock still held -- unless config.dispose() has been called (see aove),
+         *  unless       LuceneConfig.dispose() is called
+         *  which calls  LuceneIndexManager.dispose()
+         *  which calls  DirectoryLuceneIndex.dispose()
+         *  which calls  DirectoryLuceneIndex.closeWriter()
+         *  which calls  IndexWriter.close()
+         *
+         *  which frees up the lock... )
+         */
+        ioService();
+    }
+
+    public String getRepositoryName() {
+        return this.getClass().getSimpleName();
+    }
+
+    protected static File createTempDirectory() throws IOException {
+        final File temp = File.createTempFile("temp", Long.toString(System.nanoTime()));
+        if (!(temp.delete())) {
+            throw new IOException("Could not delete temp file: " + temp.getAbsolutePath());
+        }
+        if (!(temp.mkdir())) {
+            throw new IOException("Could not create temp directory: " + temp.getAbsolutePath());
+        }
+        tempFiles.add(temp);
+        return temp;
+    }
+
+    protected int seed = new Random().nextInt(10000);
+
+    protected Path getDirectoryPath() {
+        final String repositoryName = getRepositoryName();
+        final Path dir = ioService().get(URI.create("git://" + repositoryName + "/_someDir" + seed));
+        ioService().deleteIfExists(dir);
+        return dir;
+    }
+
+    protected IOService ioService() {
+        if (ioService == null) {
+            final Map<String, Analyzer> analyzers = getAnalyzers();
+            LuceneConfigBuilder configBuilder = new LuceneConfigBuilder().withInMemoryMetaModelStore().usingAnalyzers(analyzers).useDirectoryBasedIndex().useInMemoryDirectory();
+
+            configBuilder.useNIODirectory();
+            if( config == null ) {
+                config = configBuilder.build();
+            }
+
+            ioService = new IOServiceIndexedImpl(config.getIndexEngine());
+            final CountDownTestIndexer indexer = new CountDownTestIndexer(ioService, 3);
+            this.indexerCountDownLatch = indexer.getLatch();
+            IndexersFactory.clear();
+            IndexersFactory.addIndexer(indexer);
+        }
+        return ioService;
+    }
+
+    public Map<String, Analyzer> getAnalyzers() {
+        return new HashMap<String, Analyzer>() {
+            {
+                put("one", new TestAnalyzer());
+                put("two", new TestAnalyzer());
+            }
+        };
+    }
+
+    private final class TestAnalyzer extends Analyzer {
+
+        @Override
+        protected TokenStreamComponents createComponents(String fieldName) {
+            // DBG Auto-generated method stub
+            return null;
+        }
+
+    }
+
+    public final class CountDownTestIndexer implements Indexer {
+
+        private final IOService ioService;
+        private final CountDownLatch countDownLatch;
+
+        public CountDownTestIndexer(IOService ioServiceImpl, int countDown) {
+            this.ioService = ioServiceImpl;
+            this.countDownLatch = new CountDownLatch(countDown);
+        }
+
+        public CountDownLatch getLatch() {
+            return countDownLatch;
+        }
+
+        @Override
+        public boolean supportsPath(Path path) {
+            return true;
+        }
+
+        @Override
+        public KObject toKObject(Path path) {
+
+            try {
+                List<FileAttribute<?>> attrsList = new ArrayList<>();
+
+                attrsList.add(new TestFileAttribute("name", path.getFileName().toString()));
+                attrsList.add(new TestFileAttribute("path", path.toAbsolutePath().toString()));
+
+                return KObjectUtil.toKObject(path, attrsList.toArray(new FileAttribute<?>[attrsList.size()]));
+            } finally {
+                countDownLatch.countDown();
+            }
+        }
+
+        @Override
+        public KObjectKey toKObjectKey(Path path) {
+            return KObjectUtil.toKObjectKey(path);
+        }
+
+    }
+
+    private final class TestFileAttribute implements FileAttribute<Object> {
+
+        private final String name;
+        private final Object value;
+
+        public TestFileAttribute(String name, Object value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public Object value() {
+            return value;
+        }
+
+    }
+
+    protected String loadText( final String fileName ) throws IOException {
+        InputStream fileInputStream = this.getClass().getResourceAsStream( fileName );
+        if( fileInputStream == null ) {
+           File file = new File( fileName );
+           if( file.exists() ) {
+               fileInputStream = new FileInputStream(file);
+           }
+        }
+        final BufferedReader br = new BufferedReader( new InputStreamReader( fileInputStream ) );
+        try {
+            StringBuilder sb = new StringBuilder();
+            String line = br.readLine();
+
+            while ( line != null ) {
+                sb.append( line );
+                sb.append( System.getProperty( "line.separator" ) );
+                line = br.readLine();
+            }
+            return sb.toString();
+        } finally {
+            br.close();
+        }
+    }
 }

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,18 @@
+#
+# Copyright 2014 JBoss, by Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
+org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/resources/org/uberfire/ext/metadata/backend/lucene/index/one.txt
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/resources/org/uberfire/ext/metadata/backend/lucene/index/one.txt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant;
+
+rule "myRule"
+when
+  Applicant( age > 20 )
+then
+end;

--- a/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/resources/org/uberfire/ext/metadata/backend/lucene/index/two.txt
+++ b/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/resources/org/uberfire/ext/metadata/backend/lucene/index/two.txt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import org.kie.workbench.common.services.refactoring.backend.server.drl.classes.Applicant;
+
+rule "myRule"
+when
+  Applicant( age > 20 )
+then
+end;

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/KObjectUtil.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/KObjectUtil.java
@@ -87,6 +87,19 @@ public final class KObjectUtil {
             public String getKey() {
                 return path.toUri().toString();
             }
+
+            @Override
+            public String toString() {
+                StringBuilder sb = new StringBuilder( "KObject{" +
+                                                              ", key='" + getKey() + '\'' +
+                                                              ", id='" + getId() + '\'' +
+                                                              ", type=" + getType() +
+                                                              ", clusterId='" + getClusterId() + '\'' +
+                                                              ", segmentId='" + getSegmentId() + '\'' );
+                sb.append( '}' );
+
+                return sb.toString();
+            }
         };
     }
 

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/IOServiceImplDisposeTest.java
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/IOServiceImplDisposeTest.java
@@ -1,0 +1,121 @@
+package org.uberfire.ext.metadata.io;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.Test;
+import org.kie.workbench.common.services.refactoring.backend.server.indexing.DefaultIndexBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.util.KObjectUtil;
+import org.uberfire.commons.data.Pair;
+import org.uberfire.ext.metadata.engine.Indexer;
+import org.uberfire.ext.metadata.model.KObject;
+import org.uberfire.ext.metadata.model.KObjectKey;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Path;
+
+public class IOServiceImplDisposeTest extends BaseIndexTest {
+
+    @Override
+    protected String[] getRepositoryNames() {
+        return new String [] { this.getClass().getSimpleName() };
+    }
+
+    @Override
+    protected IOService ioService() {
+        if( ioService == null ) {
+            super.ioService();
+
+            IndexersFactory.clear();
+            IndexersFactory.addIndexer( new Indexer() {
+
+                @Override
+                public KObjectKey toKObjectKey( Path path ) {
+                    KObject index = null;
+
+                    try {
+
+                        Set<Pair<String, String>> indexElements = indexElements = new HashSet<>();
+
+                        index = KObjectUtil.toKObject(path, indexElements);
+                    } catch( Exception e ) {
+                        // Unexpected parsing or processing error
+                        logger.error("Unable to index '" + path.toUri().toString() + "'.", e.getMessage(), e);
+                    }
+
+                    return index;
+                    return null;
+                }
+
+                @Override
+                public KObject toKObject( Path path ) {
+                    // DBG Auto-generated method stub
+                    return null;
+                }
+
+                @Override
+                public boolean supportsPath( Path path ) {
+                    // DBG Auto-generated method stub
+                    return false;
+                }
+            };
+        }
+        return ioService;
+    }
+
+    @Test
+    public void disposeAndRecreateIOServiceTest() throws Exception {
+        IOService ioService = ioService();
+
+        final String repositoryName = this.getClass().getSimpleName();
+        int seed = new Random( 10L ).nextInt();
+        final Path dir = ioService().get(URI.create("git://" + repositoryName + "/_someDir" + seed));
+        ioService().deleteIfExists(dir);
+
+        //Add test files
+        String fileName = "file1.properties";
+        final Path path1 = dir.resolve( fileName );
+        final String drl1 = loadText( fileName );
+        ioService().write( path1, drl1 );
+
+        Thread.sleep(5000);
+
+        // dispose of IOService
+        ioService.dispose();
+
+        // .. and recreate!
+        ioService();
+    }
+
+    protected String loadText( final String fileName ) throws IOException {
+        InputStream fileInputStream = this.getClass().getResourceAsStream( fileName );
+        if( fileInputStream == null ) {
+           File file = new File( fileName );
+           if( file.exists() ) {
+               fileInputStream = new FileInputStream(file);
+           }
+        }
+        final BufferedReader br = new BufferedReader( new InputStreamReader( fileInputStream ) );
+        try {
+            StringBuilder sb = new StringBuilder();
+            String line = br.readLine();
+
+            while ( line != null ) {
+                sb.append( line );
+                sb.append( System.getProperty( "line.separator" ) );
+                line = br.readLine();
+            }
+            return sb.toString();
+        } finally {
+            br.close();
+        }
+    }
+}

--- a/uberfire-metadata/uberfire-metadata-commons-io/src/test/resources/org/uberfire/ext/metadata/io/file1.properties
+++ b/uberfire-metadata/uberfire-metadata-commons-io/src/test/resources/org/uberfire/ext/metadata/io/file1.properties
@@ -1,0 +1,2 @@
+title=Lucene in Action
+isbn=193398817


### PR DESCRIPTION
@porcelli (and @csadilek?): this is the issue I pinged you on IRC about a while back. 

This is not to say that code needs to be changed -- I don't know enough about how the `IOService` is used in the workbench/Uberfire. 

But my main point here is that calling `dispose()` on the [IOService](https://github.com/uberfire/uberfire/blob/master/uberfire-io/src/main/java/org/uberfire/io/IOService.java) is not enough if you're going to use the `IOService` on the same repository (well -- only if you're also using indexing, which might not always be the case?)

Thanks. 