### PR TITLE
[0.9.x][UF-364] uberfire-security-management: support for WFLY10/EAP7

### DIFF
--- a/uberfire-extensions-bom/pom.xml
+++ b/uberfire-extensions-bom/pom.xml
@@ -341,6 +341,19 @@
 
       <dependency>
         <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-security-management-wildfly10</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-security-management-wildfly10</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-tomcat</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/uberfire-extensions-deps/pom.xml
+++ b/uberfire-extensions-deps/pom.xml
@@ -43,6 +43,7 @@
     <version.org.jboss.resteasy.client>3.0.9.Final</version.org.jboss.resteasy.client>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
     <version.org.jboss.wildfly>8.2.0.Final</version.org.jboss.wildfly>
+    <version.org.wildfly.core>2.1.0.Final</version.org.wildfly.core>
   </properties>
 
   <dependencyManagement>
@@ -138,17 +139,28 @@
         <version>${version.org.jboss.resteasy.client}</version>
       </dependency>
       
-      <!-- Uberfire Security Management - EAP / Wdilfly. -->
+      <!-- Uberfire Security Management - EAP 6 / WildFly 8. -->
       <dependency>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-controller-client</artifactId>
         <version>${version.org.jboss.wildfly}</version>
       </dependency>
-
       <dependency>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-domain-management</artifactId>
         <version>${version.org.jboss.wildfly}</version>
+      </dependency>
+      <!-- Uberfire Security Management - EAP 7 / WildFly 10. -->
+      <dependency>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-controller-client</artifactId>
+        <version>${version.org.wildfly.core}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-domain-management</artifactId>
+        <version>${version.org.wildfly.core}</version>
       </dependency>
 
       <!-- Uberfire Security Management - Tomcat. -->

--- a/uberfire-security/uberfire-security-management/pom.xml
+++ b/uberfire-security/uberfire-security-management/pom.xml
@@ -35,6 +35,7 @@
     <module>uberfire-security-management-backend</module>
     <module>uberfire-security-management-keycloak</module>
     <module>uberfire-security-management-wildfly</module>
+    <module>uberfire-security-management-wildfly10</module>
     <module>uberfire-security-management-tomcat</module>
     <module>uberfire-security-management-client</module>
     <module>uberfire-widgets-security-management</module>

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/.gitignore
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/.gitignore
@@ -1,0 +1,18 @@
+/target
+/local
+target
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+*.ipr
+*.iws
+*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store
+
+# Created by Zanata
+/org.uberfire
+

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/README.md
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/README.md
@@ -1,0 +1,116 @@
+JBoss Wildfly / EAP provider for user and group management services
+=====================================================================
+
+Introduction
+------------
+The classes in this package contain the user and group manager implementations for JBoss Wildfly / EAP.                               
+ 
+There are two JBoss Wildfly / EAP's service implementations, use any of the following ones that fits better in your environment:                       
+
+**JBoss Wildfly / EAP provider based on property files**                  
+
+This provider supports realm types based on properties files (the default ones in JBoss server), such as `application-users.properties` or `application-roles.properties`.                                 
+
+* The user, group and role implementations are provided by `org.uberfire.ext.security.management.wildfly.properties.WildflyUserManagementService`              
+* The concrete user manager implementation is `org.uberfire.ext.security.management.wildfly.properties.WildflyUserPropertiesManager` which maps the Wildfly / EAP users for the given realm to application users
+
+* The concrete group manager implementation is `org.uberfire.ext.security.management.wildfly.properties.WildflyGroupPropertiesManager` which maps the Wildfly / EAP roles for the given realm to application groups. Wildfly/EAP realms do not have support for both groups and roles. The available roles are the ones statically defined in `org.uberfire.ext.security.server.RolesRegistry`. All other roles defined in Wildfly/EAP are considered groups.
+
+**JBoss Wildfly / EAP provider based on property files and CLI**                   
+
+This provider supports realm types based on properties files, as the above one, but instead of specifying the file system paths for the users and roles property files to manage, you can just provide JBoss Wildfly native interface connection attributes, and this implementation will use CLI commands (use of CLI remote Java API) to discover the paths of the realm property files for you.                              
+
+* The user, group and role implementations are provided by `org.uberfire.ext.security.management.wildfly.cli.WildflyCLIUserManagementService`              
+* The concrete user manager implementation is `org.uberfire.ext.security.management.wildfly.cli.WildflyUserPropertiesCLIManager` which maps the Wildfly / EAP users for the given realm to application users
+
+* The concrete group manager implementation is `org.uberfire.ext.security.management.wildfly.cli.WildflyGroupPropertiesCLIManager` which maps the Wildfly / EAP roles for the given realm to application groups. Wildfly/EAP realms do not have support for both groups and roles. The available roles are the ones statically defined in `org.uberfire.ext.security.server.RolesRegistry`. All other roles defined in Wildfly/EAP are considered groups.
+                   
+
+Installation notes
+------------------
+
+If you are deploying the application in a WildFly 10.X or an EAP 7.x, make sure you add the Wildfly / EAP controller and domain base module dependencies (provided by the server) into your application's classpath, 
+ by creating file or adding the following module dependencies in *jboss-deployment-descriptor.xml*:                                   
+
+        <jboss-deployment-structure>
+            <deployment>
+                <dependencies>
+                    <module name="org.jboss.as.controller-client"/>
+                    <module name="org.jboss.as.domain-management"/>
+                    <module name="org.jboss.sasl"/>
+                    <module name="org.jboss.msc"/>
+                    <module name="org.jboss.dmr"/>
+                </dependencies>
+            </deployment>
+        </jboss-deployment-structure>
+
+And ensure you are excluding all Wildfly / EAP controller and domain libraries, if any, from your web applications classpath, as are provided by the container.                   
+
+Usage
+-----
+
+**Using the Wildfly / EAP provider based on property files**
+
+To use this provider implementation for the users and groups management services, please choose one of the following options:               
+
+a) Specify the concrete provider to use by adding a properties file named `security-management.properties` in your web application root classpath. 
+(e.g. `src/main/resources/security-management.properties`), with the following keys and your concrete provider name as value:                               
+
+    org.uberfire.ext.security.management.api.userManagementServices=WildflyUserManagementService
+
+b) Specify the following Java system properties at container startup:        
+ 
+    -Dorg.uberfire.ext.security.management.api.userManagementServices=WildflyUserManagementService
+
+In order to use any existing users/roles properties files from a JBoss Wildfly / EAP instance, the following system properties are required to be present at startup:                 
+
+* `org.uberfire.ext.security.management.wildfly.properties.realm` - The name of the realm to use. Property is not mandatory. Defaults to `ApplicationRealm`.                  
+* `org.uberfire.ext.security.management.wildfly.properties.users-file-path` - The absolute file path for the users properties file to manage. Property is mandatory. Defaults to `./standalone/configuration/application-users.properties`.                        
+* `org.uberfire.ext.security.management.wildfly.properties.groups-file-path` - The absolute file path for the groups properties file to manage. Property is mandatory. Defaults to `./standalone/configuration/application-roles.properties`.                        
+
+**Using Wildfly / EAP provider based on property files and CLI**
+
+To use this provider implementation for the users and groups management services, please choose one of the following options:               
+
+a) Specify the concrete provider to use by adding a properties file named `security-management.properties` in your web application root classpath. 
+(e.g. `src/main/resources/security-management.properties`), with the following keys and your concrete provider name as value:                               
+
+    org.uberfire.ext.security.management.api.userManagementServices=WildflyCLIUserManagementService
+
+
+b) Specify the following Java system properties at container startup:        
+        
+    -Dorg.uberfire.ext.security.management.api.userManagementServices=WildflyCLIUserManagementService                                                                                   
+
+In order to use any existing users/roles properties files from a JBoss Wildfly / EAP instance, the following system properties are required to be present at startup:                 
+
+* `org.uberfire.ext.security.management.wildfly.cli.host` - The native administration interface host. Property is not mandatory. Defaults to `localhost`.                                       
+* `org.uberfire.ext.security.management.wildfly.cli.port` - The native administration interface port. Property is not mandatory. Defaults to `9990`.                                       
+* `org.uberfire.ext.security.management.wildfly.cli.user` - The native administration interface username. Property is not mandatory. No default value provided. Only use it if you need to specify the administration credentials for managing the server instance.                                                      
+* `org.uberfire.ext.security.management.wildfly.cli.password` - The native administration interface user's password. Property is not mandatory. No default value provided. Only use it if you need to specify the administration credentials for managing the server instance.                                                                                 
+* `org.uberfire.ext.security.management.wildfly.cli.realm` - The realm used by the application's security context. Property is not mandatory. Default value is `ApplicationRealm`.                                         
+
+Provider capabilities
+---------------------
+The Wildfly / EAP provider for users and groups management services provides the following features:                   
+
+**User service capabilities**
+* User search - Can search or list users. Search by `username`.          
+* Read user - Can read a user            
+* Create user - Can add new users            
+* Update user - Can update a user            
+* Delete user - Can delete a user            
+* Group assignment - Can manage groups for a user            
+* Role assignment - Can manage roles for a user             
+* Change password - Can change user's password            
+
+**Group service capabilities**
+* Group search - Can search or list groups. Search by `name` attribute.             
+* Read group - Can read a group            
+* Create group - Can add new groups            
+* Delete group - Can delete a group            
+
+Notes
+-----
+* Java8+
+* This implementation has been tested with `WildFly 10.0.0.Final` and `EAP 7.0.0.Final`.

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/pom.xml
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~  
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~  
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~  
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>uberfire-security-management</artifactId>
+    <groupId>org.uberfire</groupId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>uberfire-security-management-wildfly10</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Uberfire Security Management - Provider Implementation for WildFly 10</name>
+  <description>Uberfire Security Management - Provider Implementation for WildFly 10</description>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-management-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-management-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-javax-enterprise</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!-- 
+      NOTE:
+      If deploying into a JBoss Wildfly or EAP, there is no need to include these dependencies, 
+      as they are provided by container's base modules if you use the jboss-deployment-descriptor. 
+      -->
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-controller-client</artifactId>
+      <optional>true</optional>  
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-domain-management</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+
+    <!-- Testing. -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-management-backend</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/WildflyRoleManager.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/WildflyRoleManager.java
@@ -1,0 +1,28 @@
+package org.uberfire.ext.security.management.wildfly10;
+
+import org.jboss.errai.security.shared.api.Role;
+import org.uberfire.ext.security.management.UberfireRoleManager;
+import org.uberfire.ext.security.management.util.SecurityManagementUtils;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Named;
+import java.util.Set;
+
+/**
+ * <p>Custom implementation for Role Manager for the JBoss Wildfly / EAP provider.</p>
+ * <p>Using the default <code>org.uberfire.ext.security.management.UberfireRoleManager</code> the registered application roles must be present in the realm,
+ * but when using the Wildfly / EAP properties based realm, registered roles could not be present if not assigned,
+ * so consider all available roles as  all the registered ones.</p>
+ *
+ * @since 0.9.0
+ */
+@Dependent
+@Named("wildflyRoleManager")
+public class WildflyRoleManager extends UberfireRoleManager {
+
+    @Override
+    protected Set<Role> getRegisteredRoles() {
+        return SecurityManagementUtils.getRegisteredRoles();
+    }
+
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/cli/BaseWildflyCLIManager.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/cli/BaseWildflyCLIManager.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.cli;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.config.ConfigProperties;
+
+import javax.security.auth.callback.*;
+import javax.security.sasl.RealmCallback;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+
+/**
+ * <p>Base class for JBoss Wildfly security management that uses the administration Java API for managing the command line interface.</p>
+ * <p>Based on JBoss Wildfly administration API & Util classes.</p>
+ * 
+ * @since 0.9.0
+ */
+public abstract class BaseWildflyCLIManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseWildflyCLIManager.class);
+    protected static final String DEFAULT_HOST = "localhost";
+    protected static final int DEFAULT_PORT = 9990;
+    protected static final String DEFAULT_ADMIN_USER = null;
+    protected static final String DEFAULT_ADMIN_PASSWORD = null;
+    protected static final String DEFAULT_REALM = "ApplicationRealm";
+    
+    protected String host;
+    protected int port;
+    protected String adminUser;
+    protected String adminPassword;
+    protected String realm;
+
+    protected void loadConfig( final ConfigProperties config ) {
+        final ConfigProperties.ConfigProperty host = config.get("org.uberfire.ext.security.management.wildfly.cli.host", DEFAULT_HOST);
+        final ConfigProperties.ConfigProperty port = config.get("org.uberfire.ext.security.management.wildfly.cli.port", Integer.toString(DEFAULT_PORT));
+        final ConfigProperties.ConfigProperty user = config.get("org.uberfire.ext.security.management.wildfly.cli.user", DEFAULT_ADMIN_USER);
+        final ConfigProperties.ConfigProperty password = config.get("org.uberfire.ext.security.management.wildfly.cli.password", DEFAULT_ADMIN_PASSWORD);
+        final ConfigProperties.ConfigProperty realm = config.get("org.uberfire.ext.security.management.wildfly.cli.realm", DEFAULT_REALM);
+        
+        this.host = host.getValue();
+        this.port = Integer.decode(port.getValue());
+        this.adminUser = user.getValue();
+        this.adminPassword = password.getValue();
+        this.realm = realm.getValue();
+    }
+    
+    public ModelControllerClient getClient() throws Exception {
+        return ModelControllerClient.Factory.create(
+                InetAddress.getByName(host), port,
+                new CallbackHandler() {
+                    public void handle(Callback[] callbacks)
+                            throws IOException, UnsupportedCallbackException {
+                        for (Callback current : callbacks) {
+                            if (current instanceof NameCallback) {
+                                NameCallback ncb = (NameCallback) current;
+                                ncb.setName(adminUser);
+                            } else if (current instanceof PasswordCallback) {
+                                PasswordCallback pcb = (PasswordCallback) current;
+                                pcb.setPassword(adminPassword.toCharArray());
+                            } else if (current instanceof RealmCallback) {
+                                RealmCallback rcb = (RealmCallback) current;
+                                rcb.setText(rcb.getDefaultText());
+                            } else {
+                                throw new UnsupportedCallbackException(current);
+                            }
+                        }
+                    }
+                });
+    }
+
+    protected String getPropertiesFilePath(final String context) throws Exception {
+        String result = null;
+        final ModelControllerClient client = getClient();
+        if (client != null) {
+            ModelNode operation = new ModelNode();
+            operation.get("operation").set("read-resource");
+            ModelNode address = operation.get("address");
+            address.add("core-service", "management");
+            address.add("security-realm", realm);
+            address.add(context, "properties");
+            try {
+                ModelNode returnVal = client.execute(operation);
+                if ("success".equalsIgnoreCase(returnVal.get("outcome").asString())) {
+                    ModelNode resultNode = returnVal.get("result");
+                    if (resultNode != null) {
+                        String path = resultNode.get("path").asString();
+                        String relativeTo = resultNode.get("relative-to").asString();
+                        String relativeToPath = System.getProperty(relativeTo);
+                        return new File(relativeToPath, path).getAbsolutePath();
+                    }
+                }
+            } catch (Exception e) {
+                LOG.error("Error reading realm using CLI commands.", e);
+            } finally {
+                client.close();
+            }
+        }
+
+        return result;
+    }
+
+    protected static boolean isConfigPropertySet(ConfigProperties.ConfigProperty property) {
+        if (property == null) return false;
+        String value = property.getValue();
+        return !isEmpty(value);
+    }
+
+    protected static boolean isEmpty(String s) {
+        return s == null || s.trim().length() == 0;
+    }
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/cli/WildflyCLIUserManagementService.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/cli/WildflyCLIUserManagementService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.cli;
+
+import org.uberfire.ext.security.management.api.GroupManager;
+import org.uberfire.ext.security.management.api.UserManager;
+import org.uberfire.ext.security.management.service.AbstractUserManagementService;
+import org.uberfire.ext.security.management.wildfly10.WildflyRoleManager;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * <p>The Wildfly/EAP management service beans for the CLI approach.</p>
+ * 
+ * @since 0.9.0
+ */
+@Dependent
+@Named(value = "WildflyCLIUserManagementService")
+public class WildflyCLIUserManagementService extends AbstractUserManagementService {
+
+    WildflyUserPropertiesCLIManager userManager;
+    WildflyGroupPropertiesCLIManager groupManager;
+
+    @Inject
+    public WildflyCLIUserManagementService(final WildflyUserPropertiesCLIManager userManager,
+                                        final WildflyGroupPropertiesCLIManager groupManager,
+                                        final WildflyRoleManager roleManager) {
+        super(roleManager);
+        this.userManager = userManager;
+        this.groupManager = groupManager;
+    }
+    
+    @Override
+    public UserManager users() {
+        return userManager;
+    }
+
+    @Override
+    public GroupManager groups() {
+        return groupManager;
+    }
+
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/cli/WildflyGroupPropertiesCLIManager.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/cli/WildflyGroupPropertiesCLIManager.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.cli;
+
+import org.jboss.errai.security.shared.api.Group;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.config.ConfigProperties;
+import org.uberfire.ext.security.management.api.ContextualManager;
+import org.uberfire.ext.security.management.api.GroupManager;
+import org.uberfire.ext.security.management.api.GroupManagerSettings;
+import org.uberfire.ext.security.management.api.UserSystemManager;
+import org.uberfire.ext.security.management.api.exception.SecurityManagementException;
+import org.uberfire.ext.security.management.wildfly10.properties.WildflyGroupPropertiesManager;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>Groups manager service provider implementation for JBoss Wildfly.</p>
+ * <p>It wraps the Wildfly groups manager based on properties file, but instead of the need to specify the path for the properties files, its absolute path discovery is automatically handled by using to the administration API for the server.</p>
+ * 
+ * @since 0.8.0
+ */
+public class WildflyGroupPropertiesCLIManager extends BaseWildflyCLIManager implements GroupManager, ContextualManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WildflyGroupPropertiesCLIManager.class);
+    protected WildflyGroupPropertiesManager groupsPropertiesManager;
+    
+    public WildflyGroupPropertiesCLIManager() {
+        this( new ConfigProperties( System.getProperties() ) );
+    }
+
+    public WildflyGroupPropertiesCLIManager(final Map<String, String> gitPrefs) {
+        this( new ConfigProperties( gitPrefs ) );
+    }
+
+    public WildflyGroupPropertiesCLIManager(final ConfigProperties gitPrefs) {
+        loadConfig( gitPrefs );
+    }
+
+    protected  String getGroupsPropertiesFilePath() throws Exception {
+        return super.getPropertiesFilePath("authorization");
+    }
+    
+    private void init()  {
+        try {
+            final String groupsFilePath = getGroupsPropertiesFilePath();
+            final Map<String, String> arguments = new HashMap<String, String>(2);
+            arguments.put("org.uberfire.ext.security.management.wildfly.properties.realm", realm);
+            arguments.put("org.uberfire.ext.security.management.wildfly.properties.groups-file-path", groupsFilePath);
+            this.groupsPropertiesManager = new WildflyGroupPropertiesManager(arguments);
+        } catch (Exception e) {
+            LOG.error("Cannot find groups properties file using the configuration present in the server instance.", e);
+        }
+    }
+
+    @Override
+    public void initialize(UserSystemManager userSystemManager) throws Exception {
+        init();
+        groupsPropertiesManager.initialize(userSystemManager);
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        groupsPropertiesManager.destroy();
+    }
+
+    @Override
+    public SearchResponse<Group> search(SearchRequest request) throws SecurityManagementException {
+        return groupsPropertiesManager.search(request);
+    }
+
+    @Override
+    public Group get(String identifier) throws SecurityManagementException {
+        return groupsPropertiesManager.get(identifier);
+    }
+
+    @Override
+    public Group create(Group entity) throws SecurityManagementException {
+        return groupsPropertiesManager.create(entity);
+    }
+
+    @Override
+    public Group update(Group entity) throws SecurityManagementException {
+        return groupsPropertiesManager.update(entity);
+    }
+
+    @Override
+    public void delete(String... identifiers) throws SecurityManagementException {
+        groupsPropertiesManager.delete(identifiers);
+    }
+
+    @Override
+    public GroupManagerSettings getSettings() {
+        return groupsPropertiesManager.getSettings();
+    }
+
+    @Override
+    public void assignUsers(String name, Collection<String> users) throws SecurityManagementException {
+        groupsPropertiesManager.assignUsers(name, users);
+    }
+
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/cli/WildflyUserPropertiesCLIManager.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/cli/WildflyUserPropertiesCLIManager.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.cli;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.config.ConfigProperties;
+import org.uberfire.ext.security.management.api.ContextualManager;
+import org.uberfire.ext.security.management.api.UserManager;
+import org.uberfire.ext.security.management.api.UserManagerSettings;
+import org.uberfire.ext.security.management.api.UserSystemManager;
+import org.uberfire.ext.security.management.api.exception.SecurityManagementException;
+import org.uberfire.ext.security.management.wildfly10.properties.WildflyGroupPropertiesManager;
+import org.uberfire.ext.security.management.wildfly10.properties.WildflyUserPropertiesManager;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>Users manager service provider implementation for JBoss Wildfly.</p>
+ * <p>It wraps the Wildfly users manager based on properties file, but instead of the need to specify the path for the properties files, its absolute path discovery is automatically handled by using to the administration API for the server.</p>
+ * 
+ * @since 0.8.0
+ */
+public class WildflyUserPropertiesCLIManager extends BaseWildflyCLIManager implements UserManager, ContextualManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WildflyUserPropertiesCLIManager.class);
+    private WildflyUserPropertiesManager usersPropertiesManager;
+    
+    public WildflyUserPropertiesCLIManager() {
+        this( new ConfigProperties( System.getProperties() ) );
+    }
+
+    public WildflyUserPropertiesCLIManager(final Map<String, String> gitPrefs) {
+        this( new ConfigProperties( gitPrefs ) );
+    }
+
+    public WildflyUserPropertiesCLIManager(final ConfigProperties gitPrefs) {
+        loadConfig( gitPrefs );
+    }
+    
+    private String getUsersPropertiesFilePath() throws Exception {
+        return super.getPropertiesFilePath("authentication");
+    }
+    
+    private void init(final UserSystemManager usManager)  {
+        try {
+            final String usersFilePath = getUsersPropertiesFilePath();
+            final Map<String, String> arguments = new HashMap<String, String>(2);
+            arguments.put("org.uberfire.ext.security.management.wildfly.properties.realm", realm);
+            arguments.put("org.uberfire.ext.security.management.wildfly.properties.users-file-path", usersFilePath);
+            this.usersPropertiesManager = new WildflyUserPropertiesManager(arguments) {
+                @Override
+                protected synchronized WildflyGroupPropertiesManager getGroupsPropertiesManager() {
+                    try {
+                        return ((WildflyGroupPropertiesCLIManager) usManager.groups()).groupsPropertiesManager;
+                    } catch (ClassCastException e) {
+                        return super.getGroupsPropertiesManager();
+                    }
+                }
+            };
+        } catch (Exception e) {
+            LOG.error("Cannot find users properties file using the configuration present in the server instance.", e);
+        }
+    }
+
+    @Override
+    public void initialize(UserSystemManager userSystemManager) throws Exception {
+        init(userSystemManager);
+        usersPropertiesManager.initialize(userSystemManager);
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        usersPropertiesManager.destroy();
+    }
+
+    @Override
+    public void assignGroups(String username, Collection<String> groups) throws SecurityManagementException {
+        usersPropertiesManager.assignGroups(username, groups);
+    }
+
+    @Override
+    public void assignRoles(String username, Collection<String> roles) throws SecurityManagementException {
+        usersPropertiesManager.assignRoles(username, roles);
+    }
+
+    @Override
+    public void changePassword(String username, String newPassword) throws SecurityManagementException {
+        usersPropertiesManager.changePassword(username, newPassword);
+    }
+
+    @Override
+    public SearchResponse<User> search(SearchRequest request) throws SecurityManagementException {
+        return usersPropertiesManager.search(request);
+    }
+
+    @Override
+    public User get(String identifier) throws SecurityManagementException {
+        return usersPropertiesManager.get(identifier);
+    }
+
+    @Override
+    public User create(User entity) throws SecurityManagementException {
+        return usersPropertiesManager.create(entity);
+    }
+
+    @Override
+    public User update(User entity) throws SecurityManagementException {
+        return usersPropertiesManager.update(entity);
+    }
+
+    @Override
+    public void delete(String... identifiers) throws SecurityManagementException {
+        usersPropertiesManager.delete(identifiers);
+    }
+
+    @Override
+    public UserManagerSettings getSettings() {
+        return usersPropertiesManager.getSettings();
+    }
+
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/properties/BaseWildflyPropertiesManager.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/properties/BaseWildflyPropertiesManager.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.properties;
+
+import org.jboss.sasl.util.UsernamePasswordHashUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.config.ConfigProperties;
+
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * <p>Base class for JBoss Wildfly security management when using realms based on properties files.</p>
+ * <p>Based on JBoss Wildfly controller client API & Util classes.</p>
+ * 
+ * @since 0.9.0
+ */
+public abstract class BaseWildflyPropertiesManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseWildflyPropertiesManager.class);
+    public static final String DEFAULT_REALM = "ApplicationRealm";
+    
+    protected String realm = DEFAULT_REALM;
+
+    protected void loadConfig( final ConfigProperties config ) {
+        final ConfigProperties.ConfigProperty realm = config.get("org.uberfire.ext.security.management.wildfly.properties.realm", DEFAULT_REALM);
+        this.realm = realm.getValue();
+    }
+    
+    protected static String generateHashPassword(final String username, final String realm, final String password) {
+        String result = null;
+        try {
+            result = new UsernamePasswordHashUtil().generateHashedHexURP(
+                    username,
+                    realm,
+                    password.toCharArray());
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+    protected static boolean isConfigPropertySet(ConfigProperties.ConfigProperty property) {
+        if (property == null) return false;
+        String value = property.getValue();
+        return !isEmpty(value);
+    }
+
+    protected static boolean isEmpty(String s) {
+        return s == null || s.trim().length() == 0;
+    }
+
+
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyGroupPropertiesManager.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyGroupPropertiesManager.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.properties;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.as.domain.management.security.PropertiesFileLoader;
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.GroupImpl;
+import org.jboss.errai.security.shared.api.Role;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.config.ConfigProperties;
+import org.uberfire.ext.security.management.api.*;
+import org.uberfire.ext.security.management.api.exception.GroupNotFoundException;
+import org.uberfire.ext.security.management.api.exception.SecurityManagementException;
+import org.uberfire.ext.security.management.api.exception.UnsupportedServiceCapabilityException;
+import org.uberfire.ext.security.management.impl.GroupManagerSettingsImpl;
+import org.uberfire.ext.security.management.search.GroupsIdentifierRuntimeSearchEngine;
+import org.uberfire.ext.security.management.search.IdentifierRuntimeSearchEngine;
+import org.uberfire.ext.security.management.util.SecurityManagementUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * <p>Groups manager service provider implementation for JBoss Wildfly, when using default realm based on properties files.</p>
+ * 
+ * @since 0.9.0
+ */
+public class WildflyGroupPropertiesManager extends BaseWildflyPropertiesManager implements GroupManager, ContextualManager {
+
+    public static final String DEFAULT_GROUPS_FILE = "./standalone/configuration/application-roles.properties";
+    private static final Logger LOG = LoggerFactory.getLogger(WildflyGroupPropertiesManager.class);
+    private static final String GROUP_SEPARATOR = ",";
+
+    protected final IdentifierRuntimeSearchEngine<Group> groupsSearchEngine = new GroupsIdentifierRuntimeSearchEngine();
+    protected String groupsFilePath;
+    protected PropertiesFileLoader groupsPropertiesFileLoader;
+
+
+    public WildflyGroupPropertiesManager() {
+        this( new ConfigProperties( System.getProperties() ) );
+    }
+
+    public WildflyGroupPropertiesManager(final Map<String, String> gitPrefs) {
+        this( new ConfigProperties( gitPrefs ) );
+    }
+
+    public WildflyGroupPropertiesManager(final ConfigProperties gitPrefs) {
+        loadConfig( gitPrefs );
+    }
+
+    protected void loadConfig( final ConfigProperties config ) {
+        LOG.debug("Configuring JBoss provider from properties.");
+        super.loadConfig(config);
+        // Configure properties.
+        final ConfigProperties.ConfigProperty groupsFilePathProperty = config.get("org.uberfire.ext.security.management.wildfly.properties.groups-file-path", DEFAULT_GROUPS_FILE);
+        if (!isConfigPropertySet(groupsFilePathProperty)) throw new IllegalArgumentException("Property 'org.uberfire.ext.security.management.wildfly.properties.groups-file-path' is mandatory and not set.");
+        this.groupsFilePath = groupsFilePathProperty.getValue();
+        
+        LOG.debug("Configuration of JBoss provider provider finished.");
+    }
+
+    @Override
+    public void initialize(UserSystemManager userSystemManager) throws Exception {
+        this.groupsPropertiesFileLoader = getFileLoader(getGroupsFilePath());
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        this.groupsPropertiesFileLoader.stop(null);
+    }
+    
+    @Override
+    public SearchResponse<Group> search(SearchRequest request) throws SecurityManagementException {
+        Set<String> result = getAllGroups();
+        return groupsSearchEngine.searchByIdentifiers(result, request);
+    }
+
+    @Override
+    @SuppressWarnings(value = "unchecked")
+    public Group get(String identifier) throws SecurityManagementException {
+        if (identifier == null) throw new NullPointerException();
+        Set<String> result = getAllGroups();
+        if (result != null && result.contains(identifier)) return createGroup(identifier);
+        throw new GroupNotFoundException(identifier);
+    }
+
+    public Set[] getGroupsAndRolesForUser(String username) {
+        if (groupsPropertiesFileLoader != null && username != null) {
+            try {
+                final String groupsStr = groupsPropertiesFileLoader.getProperties().getProperty(username);
+                final Set<String> groups = parseGroupIdentifiers(groupsStr);
+                final Set<String> registeredRoles = SecurityManagementUtils.getRegisteredRoleNames();
+                if (groups != null) {
+                    final Set<String> allGroups = getAllGroups();
+                    if (allGroups != null) {
+                        final Set<Group> _groups = new HashSet<Group>();
+                        final Set<Role> _roles = new HashSet<Role>();
+                        for (final String name : groups) {
+                            if (!allGroups.contains(name)) {
+                                String error = "Error getting groups for user. User's group '" + name + "' does not exist.";
+                                LOG.error(error);
+                                throw new SecurityManagementException(error);
+                            }
+                            SecurityManagementUtils.populateGroupOrRoles(name, registeredRoles, _groups, _roles);
+                        }
+                        
+                        return new Set[] { _groups, _roles };
+                        
+                    }
+                }
+            } catch (IOException e) {
+                LOG.error("Error getting groups for user " + username, e);
+                throw new SecurityManagementException(e);
+            }
+        }
+        return null;
+    }
+
+    public void setGroupsForUser(String username, Collection<String> groups) {
+        if (username == null) throw new NullPointerException();
+        final String errorMsg = "Error updating groups for user " + username + ". Groups to assign must exist!";
+        if (groups != null && !existGroups(groups)) {
+            LOG.error(errorMsg);
+            throw new SecurityManagementException(errorMsg);
+        }
+        final String g = groups != null ? StringUtils.join(groups, ',') : null;
+        updateGroupProperty(username, g, errorMsg);
+    }
+    
+    public String getGroupsFilePath() {
+        return groupsFilePath;
+    }
+
+    /**
+     * Wildfly / EAP realms based on properties do not allow groups with empty users. So the groups are created using the method #assignUsers.
+     * @param entity The entity to create.
+     * @return A runtime instance for a group.
+     * @throws SecurityManagementException
+     */
+    @Override
+    public Group create(Group entity) throws SecurityManagementException {
+        if (entity == null) throw new NullPointerException();
+        return new GroupImpl(entity.getName());
+    }
+
+    @Override
+    public Group update(Group entity) throws SecurityManagementException {
+        throw new UnsupportedServiceCapabilityException(Capability.CAN_UPDATE_GROUP);
+    }
+
+    @Override
+    public void delete(String... identifiers) throws SecurityManagementException {
+        if (identifiers == null) throw new NullPointerException();
+        try {
+            Set<Map.Entry<Object, Object>> propertiesSet = groupsPropertiesFileLoader.getProperties().entrySet();
+            if (!propertiesSet.isEmpty()) {
+                for (Map.Entry<Object, Object> entry : propertiesSet) {
+                    final String username = entry.getKey().toString();
+                    final String groupsStr = entry.getValue().toString();
+                    if (groupsStr != null && groupsStr.trim().length() > 0) {
+                        final String newGroupsStr = deleteGroupsFromSerliazedValue(groupsStr, identifiers);
+                        final String errorMsg = "Error deleting groups for user " + username;
+                        updateGroupProperty(username, newGroupsStr, errorMsg);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error removing the folowing group names: " + identifiers, e);
+            throw new SecurityManagementException(e);
+        }
+    }
+    
+    private String deleteGroupsFromSerliazedValue(String groupsStr, String... identifiers) {
+        if (groupsStr != null && groupsStr.trim().length() > 0) {
+            String[] gs = groupsStr.split(",");
+            Set<String> groupSet = new HashSet<String>(gs.length);
+            Collections.addAll(groupSet, gs);
+            for (String name : identifiers) {
+                groupSet.remove(name);
+            }
+            return StringUtils.join(groupSet, ',');
+        }
+        return null;
+    }
+
+    @Override
+    public void assignUsers(String name, Collection<String> users) throws SecurityManagementException {
+        if (name == null) throw new NullPointerException();
+        if (users != null) {
+            if (users.isEmpty()) throw new RuntimeException("The realm based on properties file does not allow groups with no users assigned.");
+            for (String username : users) {
+                try {
+                    final String groupsStr = groupsPropertiesFileLoader.getProperties().getProperty(username);
+                    Set<String> groupSet = null;
+                    if (groupsStr != null && groupsStr.trim().length() > 0) {
+                        String[] gs = groupsStr.split(",");
+                        groupSet = new HashSet<String>(gs.length);
+                        Collections.addAll(groupSet, gs);
+                    } else {
+                        groupSet = new HashSet<String>(1);
+                    }
+                    groupSet.add(name);
+                    final String errorMsg = "Error updating groups for user " + username;
+                    final String newGroupsStr = StringUtils.join(groupSet, ',');
+                    updateGroupProperty(username, newGroupsStr, errorMsg);
+                } catch (IOException e) {
+                    LOG.error("Error setting groups for user " + username, e);
+                    throw new SecurityManagementException(e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public GroupManagerSettings getSettings() {
+        final Map<Capability, CapabilityStatus> capabilityStatusMap = new HashMap<Capability, CapabilityStatus>(8);
+        for (final Capability capability : SecurityManagementUtils.GROUPS_CAPABILITIES) {
+            capabilityStatusMap.put(capability, getCapabilityStatus(capability));
+        }
+        return new GroupManagerSettingsImpl(capabilityStatusMap, false);
+    }
+    
+    protected CapabilityStatus getCapabilityStatus(Capability capability) {
+        if (capability != null) {
+            switch (capability) {
+                case CAN_ADD_GROUP:
+                case CAN_DELETE_GROUP:
+                case CAN_SEARCH_GROUPS:
+                case CAN_READ_GROUP:
+                    return CapabilityStatus.ENABLED;
+            }
+        }
+        return CapabilityStatus.UNSUPPORTED;
+    }
+
+    protected  Group createGroup(String name) {
+        return SecurityManagementUtils.createGroup(name);
+    }
+
+    protected  Role createRole(String name) {
+        return SecurityManagementUtils.createRole(name);
+    }
+
+    @SuppressWarnings(value = "unchecked")
+    protected Set<String> getAllGroups() {
+        try {
+            Collection<Object> values = groupsPropertiesFileLoader.getProperties().values();
+            final HashSet<String> result = new HashSet<String>();
+            for (Object value : values) {
+                Set<String> s = parseGroupIdentifiers(value.toString());
+                if (s != null) {
+                    result.addAll(s);
+                }
+            }
+            return result;
+        } catch (IOException e) {
+            LOG.error("Error getting all groups.", e);
+            throw new SecurityManagementException(e);
+        }
+    }
+
+    void updateGroupProperty(final String name, final String groups, final String errorMessage) {
+        if (name != null) {
+            try {
+                String g = groups != null ? groups : groupsPropertiesFileLoader.getProperties().getProperty(name);
+                if ( g != null && g.trim().length() > 0) {
+                    groupsPropertiesFileLoader.getProperties().put(name, g);
+                } else {
+                    removeEntry(name);   
+                }
+                groupsPropertiesFileLoader.persistProperties();
+            } catch (IOException e) {
+                LOG.error(errorMessage, e);
+                throw new SecurityManagementException(e);
+            }
+        }
+    }
+    
+    void removeEntry(final String username) throws IOException {
+        groupsPropertiesFileLoader.getProperties().remove(username);
+        groupsPropertiesFileLoader.persistProperties();
+    }
+
+    protected  static Set<String> parseGroupIdentifiers(String groupsStr) {
+        if (groupsStr != null && groupsStr.trim().length() > 0) {
+            String[] groupsArray = groupsStr.split(GROUP_SEPARATOR);
+            Set<String> result = new HashSet<String>(groupsArray.length);
+            Collections.addAll(result, groupsArray);
+            return result;
+        }
+        return null;
+    }
+
+    protected  boolean existGroups(final Collection<String> groups) {
+        if (groups != null) {
+            final Set<String> allGroups = getAllGroups();
+            final Set<String> registeredRoles = SecurityManagementUtils.getRegisteredRoleNames();
+            if (allGroups != null && !allGroups.isEmpty()) {
+                for (String name : groups) {
+                    if (!registeredRoles.contains(name) && !allGroups.contains(name)) return false;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected  PropertiesFileLoader getFileLoader(String filePath) {
+        File propertiesFile = new File(filePath);
+        if (!propertiesFile.exists()) throw new RuntimeException("Cannot load roles/groups properties file from '" + filePath + "'.");
+
+        PropertiesFileLoader propertiesLoad = null;
+        try {
+            propertiesLoad = new PropertiesFileLoader(propertiesFile.getCanonicalPath(), null);
+            propertiesLoad.start(null);
+        } catch (Exception e) {
+            LOG.error("Error getting properties file.", e);
+            throw new SecurityManagementException(e);
+        }
+
+        return propertiesLoad;
+    }
+
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyUserManagementService.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyUserManagementService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.properties;
+
+import org.uberfire.ext.security.management.api.GroupManager;
+import org.uberfire.ext.security.management.api.UserManager;
+import org.uberfire.ext.security.management.service.AbstractUserManagementService;
+import org.uberfire.ext.security.management.wildfly10.WildflyRoleManager;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * <p>The Wildfly/EAP management service beans.</p>
+ * 
+ * @since 0.9.0
+ */
+@Dependent
+@Named(value = "WildflyUserManagementService")
+public class WildflyUserManagementService extends AbstractUserManagementService {
+
+    WildflyUserPropertiesManager userManager;
+    WildflyGroupPropertiesManager groupManager;
+
+    @Inject
+    public WildflyUserManagementService(final WildflyUserPropertiesManager userManager, 
+                                        final WildflyGroupPropertiesManager groupManager,
+                                        final @Named( "wildflyRoleManager" ) WildflyRoleManager roleManager) {
+        super(roleManager);
+        this.userManager = userManager;
+        this.groupManager = groupManager;
+    }
+
+    @Override
+    public UserManager users() {
+        return userManager;
+    }
+
+    @Override
+    public GroupManager groups() {
+        return groupManager;
+    }
+
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyUserPropertiesManager.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/main/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyUserPropertiesManager.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.properties;
+
+import org.jboss.as.domain.management.security.UserPropertiesFileLoader;
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.config.ConfigProperties;
+import org.uberfire.ext.security.management.api.Capability;
+import org.uberfire.ext.security.management.api.CapabilityStatus;
+import org.uberfire.ext.security.management.api.ContextualManager;
+import org.uberfire.ext.security.management.api.UserManager;
+import org.uberfire.ext.security.management.api.UserManagerSettings;
+import org.uberfire.ext.security.management.api.UserSystemManager;
+import org.uberfire.ext.security.management.api.exception.SecurityManagementException;
+import org.uberfire.ext.security.management.api.exception.UserNotFoundException;
+import org.uberfire.ext.security.management.impl.UserManagerSettingsImpl;
+import org.uberfire.ext.security.management.search.IdentifierRuntimeSearchEngine;
+import org.uberfire.ext.security.management.search.UsersIdentifierRuntimeSearchEngine;
+import org.uberfire.ext.security.management.util.SecurityManagementUtils;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+/**
+ * <p>Users manager service provider implementation for JBoss Wildfly, when using default realm based on properties files.</p>
+ * 
+ * @since 0.9.0
+ */
+public class WildflyUserPropertiesManager extends BaseWildflyPropertiesManager implements UserManager, ContextualManager {
+
+    public static final String DEFAULT_USERS_FILE = "./standalone/configuration/application-users.properties";
+    public static final String DEFAULT_PASSWORD = "";
+    private static final Logger LOG = LoggerFactory.getLogger(WildflyUserPropertiesManager.class);
+
+    protected final IdentifierRuntimeSearchEngine<User> usersSearchEngine = new UsersIdentifierRuntimeSearchEngine();
+    protected UserSystemManager userSystemManager;
+    protected String usersFilePath;
+    UserPropertiesFileLoader usersFileLoader;
+
+    public WildflyUserPropertiesManager() {
+        this( new ConfigProperties( System.getProperties() ) );
+    }
+
+    public WildflyUserPropertiesManager(final Map<String, String> gitPrefs) {
+        this( new ConfigProperties( gitPrefs ) );
+    }
+
+    public WildflyUserPropertiesManager(final ConfigProperties gitPrefs) {
+        loadConfig( gitPrefs );
+    }
+
+    protected void loadConfig( final ConfigProperties config ) {
+        LOG.debug("Configuring JBoss WildFly provider from properties.");
+        super.loadConfig(config);
+        final ConfigProperties.ConfigProperty usersFilePathProperty = config.get("org.uberfire.ext.security.management.wildfly.properties.users-file-path", DEFAULT_USERS_FILE);
+        if (!isConfigPropertySet(usersFilePathProperty)) throw new IllegalArgumentException("Property 'org.uberfire.ext.security.management.wildfly.properties.users-file-path' is mandatory and not set.");
+        this.usersFilePath = usersFilePathProperty.getValue();
+        LOG.debug("Configuration of JBoss WildFly provider finished.");
+    }
+
+    @Override
+    public void initialize(UserSystemManager userSystemManager) throws Exception {
+        this.userSystemManager = userSystemManager;
+        getUsersFileLoader();
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        getUsersFileLoader().stop(null);
+    }
+
+    @Override
+    public SearchResponse<User> search(SearchRequest request) throws SecurityManagementException {
+        List<String> users = getUserNames();
+        return usersSearchEngine.searchByIdentifiers(users, request);
+    }
+
+    @Override
+    public User get(String identifier) throws SecurityManagementException {
+        List<String> userNames = getUserNames();
+        if (userNames != null && userNames.contains(identifier)) {
+            Set<Group> userGroups = null;
+            Set<Role> userRoles = null;
+            if (getGroupsPropertiesManager() != null) {
+                final Set[] gr = getGroupsPropertiesManager().getGroupsAndRolesForUser(identifier);
+                if ( null != gr ) {
+                    userGroups = gr[0];
+                    userRoles = gr[1];
+                } 
+            }
+            return SecurityManagementUtils.createUser(identifier, userGroups, userRoles);
+        }
+        throw new UserNotFoundException(identifier);
+    }
+
+    public String getUsersFilePath() {
+        return usersFilePath;
+    }
+    
+    @Override
+    public User create(User entity) throws SecurityManagementException {
+        if (entity == null) throw new NullPointerException();
+        updateUserProperty(entity.getIdentifier(), "Error creating user." + entity.getIdentifier());
+        return entity;
+    }
+
+    @Override
+    public User update(User entity) throws SecurityManagementException {
+        if (entity == null) throw new NullPointerException();
+        updateUserProperty(entity.getIdentifier(), "Error updating user " + entity.getIdentifier());
+        return entity;
+    }
+
+    @Override
+    public void delete(String... usernames) throws SecurityManagementException {
+        if (usernames == null) throw new NullPointerException();
+        for (String username : usernames) {
+            final User user = get(username);
+            if (user == null) throw new UserNotFoundException(username);
+            try {
+                
+                // Remove the entry on the users properties file.
+                usersFileLoader.getProperties().remove(username);
+                usersFileLoader.persistProperties();
+
+                // Remove the entry on the groups properties file.
+                getGroupsPropertiesManager().removeEntry(username);
+                
+            } catch (IOException e) {
+                LOG.error("Error removing user " + username, e);
+                throw new SecurityManagementException(e);
+            }
+        }
+    }
+    
+    @Override
+    public void assignGroups(String username, Collection<String> groups) throws SecurityManagementException {
+        if (getGroupsPropertiesManager() != null) {
+            Set<String> userRoles = SecurityManagementUtils.rolesToString(SecurityManagementUtils.getRoles(userSystemManager, username));
+            userRoles.addAll(groups);
+            getGroupsPropertiesManager().setGroupsForUser(username, userRoles);
+        }
+    }
+
+    @Override
+    public void assignRoles(String username, Collection<String> roles) throws SecurityManagementException {
+        if (getGroupsPropertiesManager() != null) {
+            Set<String> userGroups = SecurityManagementUtils.groupsToString(SecurityManagementUtils.getGroups(userSystemManager, username));
+            userGroups.addAll(roles);
+            getGroupsPropertiesManager().setGroupsForUser(username, userGroups);
+        }
+    }
+    
+    @Override
+    public void changePassword(String username, String newPassword) throws SecurityManagementException {
+        if (username == null) throw new NullPointerException();
+        if (newPassword != null) {
+            updateUserProperty(username, generateHashPassword(username, realm, newPassword), "Error changing user's password.");
+        }
+    }
+
+    @Override
+    public UserManagerSettings getSettings() {
+        final Map<Capability, CapabilityStatus> capabilityStatusMap = new HashMap<Capability, CapabilityStatus>(8);
+        for (final Capability capability : SecurityManagementUtils.USERS_CAPABILITIES) {
+            capabilityStatusMap.put(capability, getCapabilityStatus(capability));
+        }
+        return new UserManagerSettingsImpl(capabilityStatusMap, null);
+    }
+
+    protected CapabilityStatus getCapabilityStatus(Capability capability) {
+        if (capability != null) {
+            switch (capability) {
+                case CAN_SEARCH_USERS:
+                case CAN_ADD_USER:
+                case CAN_UPDATE_USER:
+                case CAN_DELETE_USER:
+                case CAN_READ_USER:
+                case CAN_ASSIGN_GROUPS:
+                    /** As it is using the UberfireRoleManager. **/
+                case CAN_ASSIGN_ROLES:
+                case CAN_CHANGE_PASSWORD:
+                    return CapabilityStatus.ENABLED;
+            }
+        }
+        return CapabilityStatus.UNSUPPORTED;
+    }
+
+    protected  UserPropertiesFileLoader buildFileLoader(String usersFilePath) throws Exception {
+        File usersFile = new File(usersFilePath);
+        if (!usersFile.exists()) throw new RuntimeException("Properties file for users not found at '" + usersFilePath + "'.");
+
+        this.usersFileLoader =  new UserPropertiesFileLoader(usersFile.getAbsolutePath(), null) {
+            // TODO Remove this when fixed in WF. Bug: Deleted properties are still persisted to properties file
+            // as the line still present in the original property file is copied during persistProperties.
+            @Override
+            public synchronized void persistProperties() throws IOException {
+                beginPersistence();
+
+                List<String> content = readFile(propertiesFile);
+                BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(propertiesFile), Charset.forName("UTF-8")));
+                try {
+                    for (String line : content) {
+                        String trimmed = line.trim();
+                        if (trimmed.length() == 0) {
+                            bw.newLine();
+                        } else {
+                            Matcher matcher = PROPERTY_PATTERN.matcher(trimmed);
+                            if (!matcher.matches()) {
+                                write(bw, line, true);
+                            }
+                        }
+                    }
+                    endPersistence(bw);
+                } finally {
+                    safeClose(bw);
+                }
+            }
+        };
+        try {
+            this.usersFileLoader.start(null);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+
+        return this.usersFileLoader;
+
+    }
+
+    /**
+     * NOTE: To obtain the user names from the UsersFileLoader class, do not use the <code>getEnabledUserNames</code> method that comes in the jboss domain-management artifcat from Wildfly, 
+     * as this method is not present when using the jboss domain-management artifact from EAP modules, as it's version
+     * for 6.4.0.GA is quite older. So in order to be compatible with both wildfly and eap, do not use the <code>getEnabledUserNames</code> method.
+     */
+    protected  List<String> getUserNames() {
+        try {
+            final Properties properties = usersFileLoader.getProperties();
+            return toList(properties);
+        } catch (Exception e) {
+            LOG.error("Error obtaining JBoss users from properties file.", e);
+            throw new SecurityManagementException(e);
+        }
+    }
+    
+    private List<String> toList(Properties p) {
+        if ( null != p && !p.isEmpty() ) {
+            final ArrayList<String> result = new ArrayList<String>(p.size());
+            final Enumeration<?> pNames = p.propertyNames();
+            while (pNames.hasMoreElements()) {
+                final String pName = (String) pNames.nextElement();
+                final String trimmed = pName.trim();
+                if( !trimmed.startsWith("#") ) {
+                    result.add(pName);
+                }
+            }
+            return result;
+        }
+        return new ArrayList<String>(0);
+    }
+
+    protected  void updateUserProperty(final String username, final String errorMessage) {
+        updateUserProperty(username, null, errorMessage);
+    }
+
+    protected  void updateUserProperty(final String username, final String password, final String errorMessage) {
+        if (username != null) {
+            try {
+                String p = password != null ? password : usersFileLoader.getProperties().getProperty(username);
+                p = p != null ? p : DEFAULT_PASSWORD;
+                usersFileLoader.getProperties().put(username, p);
+                usersFileLoader.persistProperties();
+            } catch (IOException e) {
+                LOG.error(errorMessage, e);
+                throw new SecurityManagementException(e);
+            }
+        }
+    }
+
+    // Does not need to synchronize as the manager implements ContextualManager.
+    protected UserPropertiesFileLoader getUsersFileLoader() throws Exception {
+        if (usersFileLoader == null) {
+            this.usersFileLoader = buildFileLoader(getUsersFilePath());
+        }
+        return usersFileLoader;
+    }
+
+    protected synchronized WildflyGroupPropertiesManager getGroupsPropertiesManager() {
+        try {
+            return (WildflyGroupPropertiesManager) userSystemManager.groups();
+        } catch (ClassCastException e) {
+            return null;
+        }
+    }
+    
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/java/org/uberfire/ext/security/management/wildfly10/WildflyRoleManagerTest.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/java/org/uberfire/ext/security/management/wildfly10/WildflyRoleManagerTest.java
@@ -1,0 +1,39 @@
+package org.uberfire.ext.security.management.wildfly10;
+
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.security.server.RolesRegistry;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WildflyRoleManagerTest {
+
+    private WildflyRoleManager tested;
+
+    @Before
+    public void setup() {
+        RolesRegistry.get().clear();
+        tested = new WildflyRoleManager();
+    }
+
+    @Test
+    public void testGetRegisteredRoles() {
+        RolesRegistry.get().registerRole( "role1" );
+        RolesRegistry.get().registerRole("role2");
+        Set<Role> roles = tested.getRegisteredRoles();
+        assertNotNull(roles);
+        assertTrue(roles.size() == 3);
+        assertTrue(roles.contains(new RoleImpl( "admin" )));
+        assertTrue(roles.contains(new RoleImpl( "role1" )));
+        assertTrue(roles.contains(new RoleImpl( "role2" )));
+    }
+
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyGroupsPropertiesManagerTest.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyGroupsPropertiesManagerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.properties;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.GroupImpl;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.security.management.BaseTest;
+import org.uberfire.ext.security.management.api.AbstractEntityManager;
+import org.uberfire.ext.security.management.api.Capability;
+import org.uberfire.ext.security.management.api.CapabilityStatus;
+import org.uberfire.ext.security.management.api.UserSystemManager;
+import org.uberfire.ext.security.management.api.exception.GroupNotFoundException;
+import org.uberfire.ext.security.management.api.exception.UnsupportedServiceCapabilityException;
+import org.uberfire.ext.security.management.util.SecurityManagementUtils;
+import org.uberfire.ext.security.server.RolesRegistry;
+
+import java.io.File;
+import java.net.URL;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WildflyGroupsPropertiesManagerTest extends BaseTest {
+
+    protected static final String GROUPS_FILE = "org/uberfire/ext/security/management/wildfly10/application-roles.properties";
+    protected String groupsFilePath;
+    
+    @Spy
+    private WildflyGroupPropertiesManager groupsPropertiesManager = new WildflyGroupPropertiesManager();
+
+    private static File elHome;
+
+    @ClassRule
+    public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void initWorkspace() throws Exception {
+        elHome = tempFolder.newFolder("uf-extensions-security-management-wildfly");
+        RolesRegistry.get().clear();
+    }
+    
+    @Before
+    public void setup() throws Exception {
+        URL templateURL = Thread.currentThread().getContextClassLoader().getResource(GROUPS_FILE);
+        File templateFile = new File(templateURL.getFile());
+        FileUtils.cleanDirectory(elHome);
+        FileUtils.copyFileToDirectory(templateFile, elHome);
+        this.groupsFilePath = new File(elHome, templateFile.getName()).getAbsolutePath();
+        doReturn(groupsFilePath).when(groupsPropertiesManager).getGroupsFilePath();
+        groupsPropertiesManager.initialize(userSystemManager);
+    }
+
+    @After
+    public void finishIt() throws Exception {
+        groupsPropertiesManager.destroy();
+    }
+
+    @Test
+    public void testCapabilities() {
+        assertEquals(groupsPropertiesManager.getCapabilityStatus(Capability.CAN_SEARCH_GROUPS), CapabilityStatus.ENABLED);
+        assertEquals(groupsPropertiesManager.getCapabilityStatus(Capability.CAN_READ_GROUP), CapabilityStatus.ENABLED);
+        assertEquals(groupsPropertiesManager.getCapabilityStatus(Capability.CAN_ADD_GROUP), CapabilityStatus.ENABLED);
+        assertEquals(groupsPropertiesManager.getCapabilityStatus(Capability.CAN_DELETE_GROUP), CapabilityStatus.ENABLED);
+        assertEquals(groupsPropertiesManager.getCapabilityStatus(Capability.CAN_UPDATE_GROUP), CapabilityStatus.UNSUPPORTED);
+    }
+
+    @Test
+    public void testAllowsEmpty() {
+        assertFalse(groupsPropertiesManager.getSettings().allowEmpty());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSearchPageZero() {
+        AbstractEntityManager.SearchRequest request = buildSearchRequestMock("", 0, 5);
+        AbstractEntityManager.SearchResponse<Group> response = groupsPropertiesManager.search(request);
+    }
+    
+    @Test
+    public void testSearchAll() {
+        AbstractEntityManager.SearchRequest request = buildSearchRequestMock("", 1, 5);
+        AbstractEntityManager.SearchResponse<Group> response = groupsPropertiesManager.search(request);
+        assertNotNull(response);
+        List<Group> groups = response.getResults();
+        int total = response.getTotal();
+        boolean hasNextPage = response.hasNextPage();
+        assertEquals(total, 5);
+        assertTrue(!hasNextPage);
+        assertEquals(groups.size(), 5);
+        List<Group> expectedGroups = createGroupList("ADMIN", UserSystemManager.ADMIN, "role3", "role2", "role1");
+        assertEquals(new HashSet<Group>(expectedGroups), new HashSet<Group>(groups));
+    }
+    
+    @Test
+    public void testGroupsForUser() {
+        Set<Group> groups = groupsPropertiesManager.getGroupsAndRolesForUser(UserSystemManager.ADMIN)[0];
+        assertGroupsForUser(groups, new String[]{"ADMIN"});
+        groups = groupsPropertiesManager.getGroupsAndRolesForUser("user1")[0];
+        assertGroupsForUser(groups, new String[]{"role1"});
+        groups = groupsPropertiesManager.getGroupsAndRolesForUser("user2")[0];
+        assertGroupsForUser(groups, new String[]{"role1", "role2"});
+        groups = groupsPropertiesManager.getGroupsAndRolesForUser("user3")[0];
+        assertGroupsForUser(groups, new String[]{"role3"});
+    }
+
+    @Test
+    public void testGet() {
+        assertGet(UserSystemManager.ADMIN);
+        assertGet("role1");
+        assertGet("role2");
+        assertGet("role3");
+        assertGet("ADMIN");
+    }
+
+    @Test
+    public void testCreateGroup() {
+        Collection<String> users = new HashSet<String>();
+        users.add("user10");
+        groupsPropertiesManager.assignUsers("role10", users);
+        Group created = groupsPropertiesManager.get("role10");
+        Set<Group> groups = groupsPropertiesManager.getGroupsAndRolesForUser("user10")[0];
+        assertNotNull(created);
+        assertGroupsForUser(groups, new String[]{"role10"});
+    }
+
+    @Test(expected = UnsupportedServiceCapabilityException.class)
+    public void testUpdateGroup() {
+        Group group = mock(Group.class);
+        when(group.getName()).thenReturn("role10");
+        groupsPropertiesManager.update(group);
+    }
+
+    @Test(expected = GroupNotFoundException.class)
+    public void testDeleteGroup() {
+        groupsPropertiesManager.delete("role3");
+        groupsPropertiesManager.get("role3");
+    }
+
+    private List<Group> createGroupList(String... names) {
+        if (names != null) {
+            List<Group> result = new ArrayList<Group>(names.length);
+            for (int x = 0; x < names.length; x++) {
+                String name = names[x];
+                Group g = SecurityManagementUtils.createGroup(name);
+                result.add(g);
+            }
+            return result;
+        }
+        return null;
+    }
+    
+    private void assertGet(String name) {
+        Group group = groupsPropertiesManager.get(name);
+        assertNotNull(group);
+        assertEquals(group.getName(), name);
+    }
+
+    private void assertGroupsForUser(Set<Group> groupsSet, String[] groups) {
+        assertNotNull(groupsSet);
+        assertEquals(groupsSet.size(), groups.length);
+        int x = 0;
+        for (Group g : groupsSet) {
+            String gName = groups[x];
+            assertTrue(groupsSet.contains(new GroupImpl(gName)));
+            x++;
+        }
+    }
+    
+    
+    
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyUsersPropertiesManagerTest.java
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/java/org/uberfire/ext/security/management/wildfly10/properties/WildflyUsersPropertiesManagerTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.wildfly10.properties;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.jboss.errai.security.shared.api.identity.UserImpl;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.uberfire.ext.security.management.BaseTest;
+import org.uberfire.ext.security.management.api.*;
+import org.uberfire.ext.security.management.api.exception.UserNotFoundException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * This tests create temporary working copy of the "application-users.properties" file as the tests are run using the real wildfly admin api for realm management. 
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class WildflyUsersPropertiesManagerTest extends BaseTest {
+
+    protected static final String USERS_FILE = "org/uberfire/ext/security/management/wildfly10/application-users.properties";
+    protected String usersFilePath;
+
+    @Spy
+    private WildflyUserPropertiesManager usersPropertiesManager = new WildflyUserPropertiesManager();
+
+    @Mock private WildflyGroupPropertiesManager groupPropertiesManager;
+    
+    private static File elHome;
+    
+    @ClassRule
+    public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void initWorkspace() throws Exception {
+        elHome = tempFolder.newFolder("uf-extensions-security-management-wildfly");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        URL templateURL = Thread.currentThread().getContextClassLoader().getResource(USERS_FILE);
+        File templateFile = new File(templateURL.getFile());
+        FileUtils.cleanDirectory(elHome);
+        FileUtils.copyFileToDirectory(templateFile, elHome);
+        this.usersFilePath = new File(elHome, templateFile.getName()).getAbsolutePath();
+        doReturn(usersFilePath).when(usersPropertiesManager).getUsersFilePath();
+        usersPropertiesManager.initialize(userSystemManager);
+        doReturn(groupPropertiesManager).when(usersPropertiesManager).getGroupsPropertiesManager();
+    }
+    
+    @After
+    public void finishIt() throws Exception {
+        usersPropertiesManager.destroy();
+    }
+
+    @Test
+    public void testCapabilities() {
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_SEARCH_USERS), CapabilityStatus.ENABLED);
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_READ_USER), CapabilityStatus.ENABLED);
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_UPDATE_USER), CapabilityStatus.ENABLED);
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_ADD_USER), CapabilityStatus.ENABLED);
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_DELETE_USER), CapabilityStatus.ENABLED);
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_MANAGE_ATTRIBUTES), CapabilityStatus.UNSUPPORTED);
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_ASSIGN_GROUPS), CapabilityStatus.ENABLED);
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_CHANGE_PASSWORD), CapabilityStatus.ENABLED);
+        assertEquals(usersPropertiesManager.getCapabilityStatus(Capability.CAN_ASSIGN_ROLES), CapabilityStatus.ENABLED);
+    }
+
+    @Test
+    public void testAttributes() {
+        assertNull(usersPropertiesManager.getSettings().getSupportedAttributes());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSearchPageZero() {
+        AbstractEntityManager.SearchRequest request = buildSearchRequestMock("", 0, 5);
+        AbstractEntityManager.SearchResponse<User> response = usersPropertiesManager.search(request);
+    }
+    
+    @Test
+    public void testSearchAll() {
+        AbstractEntityManager.SearchRequest request = buildSearchRequestMock("", 1, 5);
+        AbstractEntityManager.SearchResponse<User> response = usersPropertiesManager.search(request);
+        assertNotNull(response);
+        List<User> users = response.getResults();
+        int total = response.getTotal();
+        boolean hasNextPage = response.hasNextPage();
+        assertEquals(total, 4);
+        assertTrue(!hasNextPage);
+        assertEquals(users.size(), 4);
+        Set<User> expectedUsers = new HashSet<User>(4);
+        expectedUsers.add(create(UserSystemManager.ADMIN));
+        expectedUsers.add(create("user1"));
+        expectedUsers.add(create("user2"));
+        expectedUsers.add(create("user3"));
+        assertThat(new HashSet<User>(users), is(expectedUsers));
+    }
+
+    @Test
+    public void testGetAdmin() {
+        User user = usersPropertiesManager.get(UserSystemManager.ADMIN);
+        assertUser(user, UserSystemManager.ADMIN);
+    }
+
+    @Test
+    public void testGetUser1() {
+        User user = usersPropertiesManager.get("user1");
+        assertUser(user, "user1");
+    }
+
+    @Test
+    public void testGetUser2() {
+        User user = usersPropertiesManager.get("user2");
+        assertUser(user, "user2");
+    }
+
+    @Test
+    public void testGetUser3() {
+        User user = usersPropertiesManager.get("user3");
+        assertUser(user, "user3");
+    }
+
+    @Test
+    public void testCreateUser() {
+        User user = mock(User.class);
+        when(user.getIdentifier()).thenReturn("user4");
+        User userCreated = usersPropertiesManager.create(user);
+        assertUser(userCreated, "user4");
+    }
+
+
+    @Test( expected = UserNotFoundException.class )
+    public void testDeleteUser() {
+        usersPropertiesManager.delete("user1");
+        usersPropertiesManager.get("user1");
+        try {
+            verify(groupPropertiesManager, times(1)).removeEntry("user1");
+        } catch (IOException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testAssignGroups() {
+        final User user = mock(User.class);
+        when(user.getIdentifier()).thenReturn("user1");
+        when(user.getRoles()).thenReturn(new HashSet<Role>());
+        UserManager userManagerMock = mock(UserManager.class);
+        doAnswer(new Answer<User>() {
+            @Override
+            public User answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return user;
+            }
+        }).when(userManagerMock).get("user1");
+        when(userSystemManager.users()).thenReturn(userManagerMock);
+        Collection<String> groups = new ArrayList<String>(2);
+        groups.add( "group1" );
+        groups.add( "group2" );
+        usersPropertiesManager.assignGroups("user1", groups);
+        ArgumentCaptor<Collection> groupsCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(groupPropertiesManager, times(1)).setGroupsForUser(eq("user1"), groupsCaptor.capture());
+        Collection<String> groupsCaptured = groupsCaptor.getValue();
+        assertTrue(groupsCaptured.size() == 2);
+        assertTrue(groupsCaptured.contains("group1"));
+        assertTrue(groupsCaptured.contains("group2"));
+    }
+
+    @Test
+    public void testAssignRoles() {
+        final User user = mock(User.class);
+        when(user.getIdentifier()).thenReturn("user1");
+        when(user.getGroups()).thenReturn(new HashSet<Group>());
+        UserManager userManagerMock = mock(UserManager.class);
+        doAnswer(new Answer<User>() {
+            @Override
+            public User answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return user;
+            }
+        }).when(userManagerMock).get("user1");
+        when(userSystemManager.users()).thenReturn(userManagerMock);
+        Collection<String> roles = new ArrayList<String>(2);
+        roles.add( "group1" );
+        roles.add( "group2" );
+        usersPropertiesManager.assignRoles("user1", roles);
+        ArgumentCaptor<Collection> groupsCaptor = ArgumentCaptor.forClass(Collection.class);
+        verify(groupPropertiesManager, times(1)).setGroupsForUser(eq("user1"), groupsCaptor.capture());
+        Collection<String> groupsCaptured = groupsCaptor.getValue();
+        assertTrue(groupsCaptured.size() == 2);
+        assertTrue(groupsCaptured.contains("group1"));
+        assertTrue(groupsCaptured.contains("group2"));
+    }
+
+    @Test
+    public void testChangePassword() throws Exception {
+        String oldHash = usersPropertiesManager.usersFileLoader.getProperties().getProperty("user1");
+        usersPropertiesManager.changePassword("user1", "newUser1Password");
+        String currentHash = usersPropertiesManager.usersFileLoader.getProperties().getProperty("user1");
+        assertNotEquals(oldHash, currentHash);
+    }
+
+    private User create(String username) {
+        return new UserImpl(username);
+    }
+    
+    private void assertUser(User user, String username) {
+        assertNotNull(user);
+        assertEquals(user.getIdentifier(), username);
+    }
+    
+}

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/resources/org/uberfire/ext/security/management/wildfly10/application-roles.properties
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/resources/org/uberfire/ext/security/management/wildfly10/application-roles.properties
@@ -1,0 +1,40 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates.
+#  
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  
+#    http://www.apache.org/licenses/LICENSE-2.0
+#  
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Properties declaration of users roles for the realm 'ApplicationRealm' which is the default realm
+# for application services on a new installation.
+#
+# This includes the following protocols: remote ejb, remote jndi, web, remote jms
+#
+# Users can be added to this properties file at any time, updates after the server has started
+# will be automatically detected.
+#
+# The format of this file is as follows: -
+#
+# A utility script is provided which can be executed from the bin folder to add the users: -
+# - Linux
+#  bin/add-user.sh
+#
+# - Windows
+#  bin\add-user.bat
+#
+# The following illustrates how an admin user could be defined.
+#
+admin=admin,ADMIN
+user1=role1
+user2=role1,role2
+user3=role3

--- a/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/resources/org/uberfire/ext/security/management/wildfly10/application-users.properties
+++ b/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly10/src/test/resources/org/uberfire/ext/security/management/wildfly10/application-users.properties
@@ -1,0 +1,40 @@
+#
+# Copyright 2016 Red Hat, Inc. and/or its affiliates.
+#  
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#  
+#    http://www.apache.org/licenses/LICENSE-2.0
+#  
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Properties declaration of users for the realm 'ApplicationRealm' which is the default realm
+# for application services on a new installation.
+#
+# This includes the following protocols: remote ejb, remote jndi, web, remote jms
+#
+# Users can be added to this properties file at any time, updates after the server has started
+# will be automatically detected.
+#
+# The format of this realm is as follows: -
+#
+# A utility script is provided which can be executed from the bin folder to add the users: -
+# - Linux
+#  bin/add-user.sh
+#
+# - Windows
+#  bin\add-user.bat
+# The following illustrates how an admin user could be defined, this
+# is for illustration only and does not correspond to a usable password.
+#
+admin=0cd938691c1a7cef8722398281eecdbe
+user1=9ee49fd51e158b42ba273737eea4a813
+user2=204764b333e04f93a099c4cf1dc1e64b
+user3=8f0ef3372fbf29e6317f3e397a532b8f


### PR DESCRIPTION
This is the first quick&dirty (but working) proposal, mainly to get  feedback.

Few notes:
- I basically copied the content of `uberfire-security-management-wildfly` and then did few needed code fixes. There is a certain duplication. It's just few classes, but still. If we agree it is worth the effort, I will extract the common code into some third module, and reuse it in the two specific ones.
- since WFLY10 requires Java 8, this change also means we need Java 8 to build uberfire
- I kept the original name `uberfire-security-management-wildfly`. We could rename that to `*-wildfly8`, but that would mean breaking backwards compatibility. Not sure what is worse in this case - inconsistent naming or breaking compatibility.

@ederign, @dgutierr, @romartin please take a look.
