### PR TITLE
[0.9.x] RHBRMS-2687: [Screen Plugin] Fail to upload picture on WAS and IE11

### DIFF
--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/main/java/org/uberfire/ext/plugin/backend/MediaServletURIProducer.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/main/java/org/uberfire/ext/plugin/backend/MediaServletURIProducer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.plugin.backend;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+import org.uberfire.commons.services.cdi.Startup;
+import org.uberfire.commons.services.cdi.StartupType;
+
+@ApplicationScoped
+@Startup(StartupType.BOOTSTRAP)
+public class MediaServletURIProducer {
+
+    private MediaServletURI mediaServletURI;
+
+    @PostConstruct
+    public void setup() {
+        mediaServletURI = new MediaServletURI( "plugins/" );
+    }
+
+    @Produces
+    @Named("MediaServletURI")
+    public MediaServletURI produceMediaServletURI() {
+        return mediaServletURI;
+    }
+}

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/main/java/org/uberfire/ext/plugin/backend/PluginMediaServlet.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/main/java/org/uberfire/ext/plugin/backend/PluginMediaServlet.java
@@ -55,7 +55,9 @@ public class PluginMediaServlet
 
     private String pattern = "/plugins/";
 
-    private static MediaServletURI mediaServletURI = new MediaServletURI( "plugins/" );
+    @Inject
+    @Named("MediaServletURI")
+    private MediaServletURI mediaServletURI;
 
     private FileSystem fileSystem;
 
@@ -86,12 +88,6 @@ public class PluginMediaServlet
             fileSystem = ioService.getFileSystem( URI.create( "default://plugins" ) );
         }
         this.root = fileSystem.getRootDirectories().iterator().next();
-    }
-
-    @Produces
-    @Named("MediaServletURI")
-    public MediaServletURI produceMediaServletURI() {
-        return mediaServletURI;
     }
 
     @Override

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/test/java/org/uberfire/ext/plugin/backend/MediaServletURIProducerTest.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/test/java/org/uberfire/ext/plugin/backend/MediaServletURIProducerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.plugin.backend;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MediaServletURIProducerTest {
+
+    private MediaServletURIProducer mediaServletURIProducer = new MediaServletURIProducer();
+
+    @Test
+    public void testSetup() throws Exception {
+        mediaServletURIProducer.setup();
+
+        assertEquals( "plugins/", getMediaServletURI().getURI() );
+    }
+
+    private MediaServletURI getMediaServletURI() {
+        return mediaServletURIProducer.produceMediaServletURI();
+    }
+}

--- a/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/test/java/org/uberfire/ext/plugin/backend/PluginMediaServletTest.java
+++ b/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/test/java/org/uberfire/ext/plugin/backend/PluginMediaServletTest.java
@@ -17,16 +17,60 @@
 package org.uberfire.ext.plugin.backend;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.Iterator;
+import javax.servlet.ServletConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
 
 import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 public class PluginMediaServletTest {
+
+    @Mock
+    FileSystem fileSystem;
+
+    @Mock
+    Iterable<Path> iterable;
+
+    @Mock
+    Iterator<Path> iterator;
+
+    @Mock
+    ServletConfig config;
+
+    @Mock
+    IOService ioService;
+
+    @Mock
+    MediaServletURI mediaServletURI;
+
+    @InjectMocks
+    PluginMediaServlet servlet = fakeServlet();
+
+    @Test
+    public void testInit() throws Exception {
+        when( iterable.iterator() ).thenReturn( iterator );
+        when( fileSystem.getRootDirectories() ).thenReturn( iterable );
+        when( config.getInitParameter( anyString() ) ).thenReturn( "/fake" );
+        when( ioService.newFileSystem( any( URI.class ), anyMapOf( String.class, Class.class ) ) ).thenReturn( fileSystem );
+
+        servlet.init( config );
+
+        verify( mediaServletURI ).setURI( eq( "fake/" ) );
+    }
 
     @Test
     public void testDoPost() throws Exception {
@@ -60,6 +104,10 @@ public class PluginMediaServletTest {
         when( fileItem.getName() ).thenReturn( fileName );
 
         return fileItem;
+    }
+
+    private PluginMediaServlet fakeServlet() {
+        return fakeServlet( null );
     }
 
     private PluginMediaServlet fakeServlet( final FileItem fileItem ) {


### PR DESCRIPTION
The `MediaServletURI` injection was not working because the method `produceMediaServletURI ` was not being used by WAS.

See https://issues.jboss.org/browse/RHBRMS-2687
